### PR TITLE
Add modular ontology generator

### DIFF
--- a/build/lexicon.ttl
+++ b/build/lexicon.ttl
@@ -1,0 +1,3856 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bsky: <https://atproto.social/ontology/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost> rdfs:comment "FeedDefs_SkeletonFeedPost is a "skeletonFeedPost" in the app.bsky.feed.defs schema." .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost/post> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost/post> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost/post> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost/reason> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost/reason> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost/reason> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost/feedContext> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost/feedContext> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost/feedContext> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonFeedPost/feedContext> rdfs:comment "feedContext: Context that will be passed through to client and may be passed to feed generator back alongside interactions." .
+<https://atproto.social/ontology/app.bsky.feed.defs#ContentModeUnspecified> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ContentModeUnspecified> rdfs:comment "Declares the feed generator returns any types of posts." .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Main> rdfs:comment "Annotation of a sub-string within rich text." .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Main/index> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Main/index> rdfs:domain <https://atproto.social/ontology/app.bsky.richtext.facet#Main> .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Main/index> rdfs:range <https://atproto.social/ontology/app.bsky.richtext.facet#ByteSlice> .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Main/features> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Main/features> rdfs:domain <https://atproto.social/ontology/app.bsky.richtext.facet#Main> .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Main/features> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.team.defs#RoleTriage> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.team.defs#RoleTriage> rdfs:comment "Triage role. Mostly intended for monitoring and escalating issues." .
+<https://atproto.social/ontology/chat.bsky.actor.deleteAccount#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.getHostStatus#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.getHostStatus#Main> rdfs:comment "Returns information about a specified upstream host, as consumed by the server. Implemented by relays." .
+<https://atproto.social/ontology/tools.ozone.set.deleteSet#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.set.deleteSet#Main> rdfs:comment "Delete an entire set. Attempting to delete a set that does not exist will result in an error." .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref> rdfs:comment "ActorDefs_SavedFeedsPref is a "savedFeedsPref" in the app.bsky.actor.defs schema.
+
+RECORDTYPE: ActorDefs_SavedFeedsPref" .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref/pinned> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref/pinned> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref/pinned> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref/saved> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref/saved> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref/saved> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref/timelineIndex> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref/timelineIndex> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPref/timelineIndex> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.graph.getFollows#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getFollows#Main> rdfs:comment "Enumerates accounts which a specified account (actor) follows." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView> rdfs:comment "UnspeccedDefs_TrendView is a "trendView" in the app.bsky.unspecced.defs schema." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/link> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/link> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/link> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/startedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/startedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/startedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/postCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/postCount> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/postCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/status> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/status> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/status> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/category> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/category> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/category> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/actors> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/actors> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/actors> rdfs:range <https://atproto.social/ontology/app.bsky.unspecced.defs#App.bsky.actor.defs#profileViewBasic> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/topic> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/topic> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/topic> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/displayName> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/displayName> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendView/displayName> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestedStarterPacks#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestedStarterPacks#Main> rdfs:comment "Get a list of suggested starterpacks" .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> rdfs:comment "ActorDefs_ProfileView is a "profileView" in the app.bsky.actor.defs schema." .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/handle> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/displayName> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/displayName> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/displayName> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/description> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/description> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/description> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/associated> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/associated> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/associated> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/createdAt> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/labels> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/did> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/status> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/status> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/status> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#StatusView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/verification> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/verification> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/verification> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#VerificationState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/viewer> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/viewer> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/viewer> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/avatar> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/avatar> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileView/avatar> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent> rdfs:comment "Logs identity related events on a repo subject. Normally captured by automod from the firehose and emitted to ozone for historical tracking." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/handle> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/pdsHost> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/pdsHost> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/pdsHost> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/tombstone> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/tombstone> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/tombstone> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/timestamp> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/timestamp> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#IdentityEvent/timestamp> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/uri> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/cid> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/value> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/value> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/blobs> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/blobs> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/blobs> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/labels> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/labels> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/indexedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/moderation> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/moderation> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/moderation> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#ModerationDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/repo> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/repo> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail/repo> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#Main> rdfs:comment "Get accounts that share some matching threat signatures with the root account." .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition> a owl:Class .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition> rdfs:comment "Declares a label value and its expected interpretations and behaviors." .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/defaultSetting> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/defaultSetting> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition> .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/defaultSetting> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/defaultSetting> rdfs:comment "The default setting for this label." .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/adultOnly> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/adultOnly> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition> .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/adultOnly> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/adultOnly> rdfs:comment "Does the user need to have adult content enabled in order to configure this label?" .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/locales> a owl:ObjectProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/locales> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition> .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/locales> rdfs:range <https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings> .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/identifier> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/identifier> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition> .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/identifier> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/identifier> rdfs:comment "The value of the label being defined. Must only include lowercase ascii and the '-' character ([a-z-]+)." .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/severity> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/severity> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition> .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/severity> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/severity> rdfs:comment "How should a client visually convey this label? 'inform' means neutral and informational; 'alert' means negative and warning; 'none' means show nothing." .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/blurs> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/blurs> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition> .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/blurs> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinition/blurs> rdfs:comment "What should this label hide in the UI, if applied? 'content' hides all of the target; 'media' hides the images/video/audio; 'none' hides nothing." .
+<https://atproto.social/ontology/com.atproto.label.queryLabels#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.label.queryLabels#Main> rdfs:comment "Find labels relevant to the provided AT-URI patterns. Public endpoint for moderation services, though may return different or additional results with auth." .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Labels> a owl:Class .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Labels/seq> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Labels/seq> rdfs:domain <https://atproto.social/ontology/com.atproto.label.subscribeLabels#Labels> .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Labels/seq> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Labels/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Labels/labels> rdfs:domain <https://atproto.social/ontology/com.atproto.label.subscribeLabels#Labels> .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Labels/labels> rdfs:range <https://atproto.social/ontology/com.atproto.label.subscribeLabels#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMuteReporter> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMuteReporter> rdfs:comment "Mute incoming reports from an account" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMuteReporter/durationInHours> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMuteReporter/durationInHours> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMuteReporter> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMuteReporter/durationInHours> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMuteReporter/durationInHours> rdfs:comment "Indicates how long the account should remain muted. Falsy value here means a permanent mute." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMuteReporter/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMuteReporter/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMuteReporter> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMuteReporter/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Tag> a owl:Class .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Tag> rdfs:comment "RichtextFacet_Tag is a "tag" in the app.bsky.richtext.facet schema.
+
+Facet feature for a hashtag. The text usually includes a '#' prefix, but the facet reference should not (except in the case of 'double hash tags').
+
+RECORDTYPE: RichtextFacet_Tag" .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Tag/tag> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Tag/tag> rdfs:domain <https://atproto.social/ontology/app.bsky.richtext.facet#Tag> .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Tag/tag> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#Label> a owl:Class .
+<https://atproto.social/ontology/com.atproto.label.defs#Label> rdfs:comment "Metadata tag on an atproto resource (eg, repo or record)." .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/ver> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/ver> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#Label> .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/ver> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/ver> rdfs:comment "The AT Protocol version of the label object." .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/src> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/src> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#Label> .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/src> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/src> rdfs:comment "DID of the actor who created this label." .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/uri> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#Label> .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/uri> rdfs:comment "AT URI of the record, repository (account), or other resource that this label applies to." .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/cid> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#Label> .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/cid> rdfs:comment "Optionally, CID specifying the specific version of 'uri' resource this label applies to." .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/val> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/val> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#Label> .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/val> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/val> rdfs:comment "The short string name of the value or type of this label." .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/neg> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/neg> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#Label> .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/neg> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/neg> rdfs:comment "If true, this is a negation label, overwriting a previous label." .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/cts> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/cts> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#Label> .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/cts> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/cts> rdfs:comment "Timestamp when this label was created." .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/exp> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/exp> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#Label> .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/exp> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/exp> rdfs:comment "Timestamp at which this label expires (no longer applies)." .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/sig> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/sig> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#Label> .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/sig> rdfs:range xsd:base64Binary .
+<https://atproto.social/ontology/com.atproto.label.defs#Label/sig> rdfs:comment "Signature of dag-cbor encoded label." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/handle> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/email> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/email> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/email> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/moderation> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/moderation> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/moderation> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#ModerationDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/invites> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/invites> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/invites> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#Com.atproto.server.defs#inviteCode> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/indexedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/labels> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/labels> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/emailConfirmedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/emailConfirmedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/emailConfirmedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/deactivatedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/deactivatedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/deactivatedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/threatSignatures> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/threatSignatures> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/threatSignatures> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#Com.atproto.admin.defs#threatSignature> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/did> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/relatedRecords> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/relatedRecords> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/relatedRecords> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/invitedBy> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/invitedBy> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/invitedBy> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#Com.atproto.server.defs#inviteCode> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/invitesDisabled> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/invitesDisabled> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/invitesDisabled> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/inviteNote> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/inviteNote> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail/inviteNote> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> rdfs:comment "FeedDefs_GeneratorView is a "generatorView" in the app.bsky.feed.defs schema.
+
+RECORDTYPE: FeedDefs_GeneratorView" .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/displayName> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/displayName> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/displayName> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/descriptionFacets> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/descriptionFacets> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/descriptionFacets> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#App.bsky.richtext.facet> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/avatar> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/avatar> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/avatar> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/likeCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/likeCount> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/likeCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/acceptsInteractions> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/acceptsInteractions> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/acceptsInteractions> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/description> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/description> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/description> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/did> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/creator> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/creator> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/creator> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#App.bsky.actor.defs#profileView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/contentMode> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/contentMode> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/contentMode> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/labels> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/viewer> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/viewer> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/viewer> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorViewerState> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorView/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.deleteMessageForSelf#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.deleteRecord#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.deleteRecord#Main> rdfs:comment "Delete a repository record, or ensure it doesn't exist. Requires auth, implemented by PDS." .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#AccountCreated> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#AccountCreated/email> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#AccountCreated/email> rdfs:domain <https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#AccountCreated> .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#AccountCreated/email> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#AccountCreated/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#AccountCreated/handle> rdfs:domain <https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#AccountCreated> .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#AccountCreated/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.getRepo#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.getRepo#Main> rdfs:comment "Download a repository export as CAR file. Optionally only a 'diff' since a previous revision. Does not require auth; implemented by PDS." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/details> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/details> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/details> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/moderation> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/moderation> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/moderation> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#Moderation> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/cid> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/mimeType> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/mimeType> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/mimeType> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/size> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/size> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/size> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.getList#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getList#Main> rdfs:comment "Gets a 'view' (with additional context) of a specified list." .
+<https://atproto.social/ontology/app.bsky.notification.listActivitySubscriptions#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.listActivitySubscriptions#Main> rdfs:comment "Enumerate all accounts to which the requesting account is subscribed to receive notifications for. Requires auth." .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogBeginConvo> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogBeginConvo/convoId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogBeginConvo/convoId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogBeginConvo> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogBeginConvo/convoId> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogBeginConvo/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogBeginConvo/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogBeginConvo> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogBeginConvo/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.identity.resolveIdentity#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.identity.resolveIdentity#Main> rdfs:comment "Resolves an identity (DID or Handle) to a full identity (DID document and verified handle)." .
+<https://atproto.social/ontology/app.bsky.unspecced.getConfig#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getConfig#Main> rdfs:comment "Get miscellaneous runtime configuration." .
+<https://atproto.social/ontology/app.bsky.actor.getSuggestions#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.getSuggestions#Main> rdfs:comment "Get a list of suggested actors. Expected use is discovery of accounts to follow during new account onboarding." .
+<https://atproto.social/ontology/com.atproto.identity.resolveDid#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.identity.resolveDid#Main> rdfs:comment "Resolves DID to DID document. Does not bi-directionally verify handle." .
+<https://atproto.social/ontology/com.atproto.label.defs#SelfLabels> a owl:Class .
+<https://atproto.social/ontology/com.atproto.label.defs#SelfLabels> rdfs:comment "Metadata tags on an atproto record, published by the author within the record." .
+<https://atproto.social/ontology/com.atproto.label.defs#SelfLabels/values> a owl:ObjectProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#SelfLabels/values> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#SelfLabels> .
+<https://atproto.social/ontology/com.atproto.label.defs#SelfLabels/values> rdfs:range <https://atproto.social/ontology/com.atproto.label.defs#SelfLabel> .
+<https://atproto.social/ontology/com.atproto.admin.disableAccountInvites#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.disableAccountInvites#Main> rdfs:comment "Disable an account from receiving new invite codes, but does not invalidate existing codes." .
+<https://atproto.social/ontology/com.atproto.admin.updateSubjectStatus#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.updateSubjectStatus#Main> rdfs:comment "Update the service-specific admin status of a subject (account, record, or blob)." .
+<https://atproto.social/ontology/tools.ozone.server.getConfig#ViewerConfig> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.server.getConfig#ViewerConfig/role> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.server.getConfig#ViewerConfig/role> rdfs:domain <https://atproto.social/ontology/tools.ozone.server.getConfig#ViewerConfig> .
+<https://atproto.social/ontology/tools.ozone.server.getConfig#ViewerConfig/role> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.queryEvents#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.queryEvents#Main> rdfs:comment "List moderation events related to a subject." .
+<https://atproto.social/ontology/app.bsky.feed.getActorFeeds#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getActorFeeds#Main> rdfs:comment "Get a list of feeds (feed generator records) created by the actor (in the actor's repo)." .
+<https://atproto.social/ontology/app.bsky.graph.unmuteActor#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.unmuteActor#Main> rdfs:comment "Unmutes the specified account. Requires auth." .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonMisleading> a owl:Class .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonMisleading> rdfs:comment "Misleading identity, affiliation, or content" .
+<https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword/name> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword/name> rdfs:domain <https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword> .
+<https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword/name> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword/createdAt> rdfs:domain <https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword> .
+<https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword/privileged> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword/privileged> rdfs:domain <https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword> .
+<https://atproto.social/ontology/com.atproto.server.listAppPasswords#AppPassword/privileged> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/chat.bsky.convo.addReaction#Main> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.addReaction#Main> rdfs:comment "Adds an emoji reaction to a message. Requires authentication. It is idempotent, so multiple calls from the same user with the same emoji result in a single reaction." .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Info> a owl:Class .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Info/name> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Info/name> rdfs:domain <https://atproto.social/ontology/com.atproto.label.subscribeLabels#Info> .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Info/name> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Info/message> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Info/message> rdfs:domain <https://atproto.social/ontology/com.atproto.label.subscribeLabels#Info> .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Info/message> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.createRecord#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.createRecord#Main> rdfs:comment "Create a single new repository record. Requires auth, implemented by PDS." .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState> rdfs:comment "ActorDefs_VerificationState is a "verificationState" in the app.bsky.actor.defs schema.
+
+Represents the verification information about the user this object is attached to." .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState/verifications> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState/verifications> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#VerificationState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState/verifications> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#VerificationView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState/verifications> rdfs:comment "verifications: All verifications issued by trusted verifiers on behalf of this user. Verifications by untrusted verifiers are not included." .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState/verifiedStatus> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState/verifiedStatus> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#VerificationState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState/verifiedStatus> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState/verifiedStatus> rdfs:comment "verifiedStatus: The user's status as a verified account." .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState/trustedVerifierStatus> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState/trustedVerifierStatus> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#VerificationState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState/trustedVerifierStatus> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationState/trustedVerifierStatus> rdfs:comment "trustedVerifierStatus: The user's status as a trusted verifier." .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost> rdfs:comment "FeedDefs_ThreadViewPost is a "threadViewPost" in the app.bsky.feed.defs schema.
+
+RECORDTYPE: FeedDefs_ThreadViewPost" .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost/post> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost/post> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost/post> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost/parent> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost/parent> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost/parent> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost/replies> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost/replies> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost/replies> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost/threadContext> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost/threadContext> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadViewPost/threadContext> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#ThreadContext> .
+<https://atproto.social/ontology/app.bsky.feed.getActorLikes#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getActorLikes#Main> rdfs:comment "Get a list of posts liked by an actor. Requires auth, actor must be the requesting account." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemBlocked> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemBlocked> rdfs:comment "UnspeccedDefs_ThreadItemBlocked is a "threadItemBlocked" in the app.bsky.unspecced.defs schema.
+
+RECORDTYPE: UnspeccedDefs_ThreadItemBlocked" .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemBlocked/author> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemBlocked/author> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemBlocked> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemBlocked/author> rdfs:range <https://atproto.social/ontology/app.bsky.unspecced.defs#App.bsky.feed.defs#blockedAuthor> .
+<https://atproto.social/ontology/app.bsky.embed.video#View> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.video#View> rdfs:comment "EmbedVideo_View is a "view" in the app.bsky.embed.video schema.
+
+RECORDTYPE: EmbedVideo_View" .
+<https://atproto.social/ontology/app.bsky.embed.video#View/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.video#View/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.video#View> .
+<https://atproto.social/ontology/app.bsky.embed.video#View/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.video#View/playlist> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.video#View/playlist> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.video#View> .
+<https://atproto.social/ontology/app.bsky.embed.video#View/playlist> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.video#View/thumbnail> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.video#View/thumbnail> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.video#View> .
+<https://atproto.social/ontology/app.bsky.embed.video#View/thumbnail> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.video#View/alt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.video#View/alt> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.video#View> .
+<https://atproto.social/ontology/app.bsky.embed.video#View/alt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.video#View/aspectRatio> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.video#View/aspectRatio> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.video#View> .
+<https://atproto.social/ontology/app.bsky.embed.video#View/aspectRatio> rdfs:range <https://atproto.social/ontology/app.bsky.embed.video#App.bsky.embed.defs#aspectRatio> .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoRef> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoRef/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoRef/did> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#RepoRef> .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoRef/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#PasswordUpdated> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.refreshSession#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.refreshSession#Main> rdfs:comment "Refresh an authentication session. Requires auth using the 'refreshJwt' (not the 'accessJwt')." .
+<https://atproto.social/ontology/com.atproto.server.listAppPasswords#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.listAppPasswords#Main> rdfs:comment "List all App Passwords." .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#Main> rdfs:comment "Grant verifications to multiple subjects. Allows batch processing of up to 100 verifications at once." .
+<https://atproto.social/ontology/app.bsky.graph.defs#NotFoundActor> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.defs#NotFoundActor> rdfs:comment "GraphDefs_NotFoundActor is a "notFoundActor" in the app.bsky.graph.defs schema.
+
+indicates that a handle or DID could not be resolved
+
+RECORDTYPE: GraphDefs_NotFoundActor" .
+<https://atproto.social/ontology/app.bsky.graph.defs#NotFoundActor/actor> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#NotFoundActor/actor> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#NotFoundActor> .
+<https://atproto.social/ontology/app.bsky.graph.defs#NotFoundActor/actor> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#NotFoundActor/notFound> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#NotFoundActor/notFound> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#NotFoundActor> .
+<https://atproto.social/ontology/app.bsky.graph.defs#NotFoundActor/notFound> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListItemView> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListItemView> rdfs:comment "GraphDefs_ListItemView is a "listItemView" in the app.bsky.graph.defs schema." .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListItemView/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListItemView/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListItemView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListItemView/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListItemView/subject> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListItemView/subject> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListItemView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListItemView/subject> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#App.bsky.actor.defs#profileView> .
+<https://atproto.social/ontology/app.bsky.graph.getMutes#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getMutes#Main> rdfs:comment "Enumerates accounts that the requesting account (actor) currently has muted. Requires auth." .
+<https://atproto.social/ontology/com.atproto.label.defs#SelfLabel> a owl:Class .
+<https://atproto.social/ontology/com.atproto.label.defs#SelfLabel> rdfs:comment "Metadata tag on an atproto record, published by the author within the record. Note that schemas should use #selfLabels, not #selfLabel." .
+<https://atproto.social/ontology/com.atproto.label.defs#SelfLabel/val> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#SelfLabel/val> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#SelfLabel> .
+<https://atproto.social/ontology/com.atproto.label.defs#SelfLabel/val> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#SelfLabel/val> rdfs:comment "The short string name of the value or type of this label." .
+<https://atproto.social/ontology/chat.bsky.convo.sendMessage#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.set.defs#Set> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.set.defs#Set/name> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.set.defs#Set/name> rdfs:domain <https://atproto.social/ontology/tools.ozone.set.defs#Set> .
+<https://atproto.social/ontology/tools.ozone.set.defs#Set/name> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.set.defs#Set/description> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.set.defs#Set/description> rdfs:domain <https://atproto.social/ontology/tools.ozone.set.defs#Set> .
+<https://atproto.social/ontology/tools.ozone.set.defs#Set/description> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.actor.declaration#Main> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.actor.declaration#Main> rdfs:comment "A declaration of a Bluesky chat account." .
+<https://atproto.social/ontology/com.atproto.admin.updateAccountEmail#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.updateAccountEmail#Main> rdfs:comment "Administrative action to update an account's email." .
+<https://atproto.social/ontology/chat.bsky.convo.removeReaction#Main> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.removeReaction#Main> rdfs:comment "Removes an emoji reaction from a message. Requires authentication. It is idempotent, so multiple calls from the same user with the same emoji result in that reaction not being present, even if it already wasn't." .
+<https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo> a owl:Class .
+<https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo/did> rdfs:domain <https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo> .
+<https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo/handle> rdfs:domain <https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo> .
+<https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo/handle> rdfs:comment "The validated handle of the account; or 'handle.invalid' if the handle did not bi-directionally match the DID document." .
+<https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo/didDoc> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo/didDoc> rdfs:domain <https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo> .
+<https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo/didDoc> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.identity.defs#IdentityInfo/didDoc> rdfs:comment "The complete DID document for the identity." .
+<https://atproto.social/ontology/com.atproto.server.checkAccountStatus#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.checkAccountStatus#Main> rdfs:comment "Returns the status of an account, especially as pertaining to import or recovery. Can be called many times over the course of an account migration. Requires auth and can only be called pertaining to oneself." .
+<https://atproto.social/ontology/com.atproto.sync.listReposByCollection#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.listReposByCollection#Main> rdfs:comment "Enumerates all the DIDs which have records with the given collection NSID." .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState> rdfs:comment "FeedDefs_ViewerState is a "viewerState" in the app.bsky.feed.defs schema.
+
+Metadata about the requesting account's relationship with the subject content. Only has meaningful content for authed requests." .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/repost> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/repost> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/repost> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/like> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/like> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/like> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/threadMuted> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/threadMuted> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/threadMuted> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/replyDisabled> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/replyDisabled> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/replyDisabled> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/embeddingDisabled> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/embeddingDisabled> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/embeddingDisabled> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/pinned> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/pinned> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ViewerState/pinned> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.video.getUploadLimits#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.video.getUploadLimits#Main> rdfs:comment "Get video upload limits for the authenticated user." .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage/convoId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage/convoId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage/convoId> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage/message> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage/message> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage/message> rdfs:range owl:Thing .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogDeleteMessage/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.sendMessageBatch#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView> rdfs:comment "ActorDefs_VerificationView is a "verificationView" in the app.bsky.actor.defs schema.
+
+An individual verification for an associated subject." .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/issuer> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/issuer> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#VerificationView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/issuer> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/issuer> rdfs:comment "issuer: The user who issued this verification." .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#VerificationView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/uri> rdfs:comment "uri: The AT-URI of the verification record." .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/isValid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/isValid> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#VerificationView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/isValid> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/isValid> rdfs:comment "isValid: True if the verification passes validation, otherwise false." .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/createdAt> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#VerificationView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationView/createdAt> rdfs:comment "createdAt: Timestamp when the verification was created." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEscalate> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEscalate/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEscalate/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEscalate> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEscalate/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.profile#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.profile#Main> rdfs:comment "A declaration of a Bluesky account profile." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/status> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/status> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/status> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/updatedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/updatedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/updatedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/deletedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/deletedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/deletedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/deactivatedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/deactivatedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/deactivatedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/reactivatedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/reactivatedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountHosting/reactivatedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal> rdfs:comment "EmbedExternal_ViewExternal is a "viewExternal" in the app.bsky.embed.external schema." .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.external#ViewExternal> .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal/title> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal/title> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.external#ViewExternal> .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal/title> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal/description> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal/description> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.external#ViewExternal> .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal/description> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal/thumb> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal/thumb> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.external#ViewExternal> .
+<https://atproto.social/ontology/app.bsky.embed.external#ViewExternal/thumb> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.postgate#DisableRule> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.postgate#DisableRule> rdfs:comment "FeedPostgate_DisableRule is a "disableRule" in the app.bsky.feed.postgate schema.
+
+Disables embedding of this post.
+
+RECORDTYPE: FeedPostgate_DisableRule" .
+<https://atproto.social/ontology/app.bsky.feed.defs#RequestLess> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#RequestLess> rdfs:comment "Request that less content like the given feed item be shown in the feed" .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogUnmuteConvo> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogUnmuteConvo/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogUnmuteConvo/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogUnmuteConvo> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogUnmuteConvo/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogUnmuteConvo/convoId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogUnmuteConvo/convoId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogUnmuteConvo> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogUnmuteConvo/convoId> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Main> rdfs:comment "Apply a batch transaction of repository creates, updates, and deletes. Requires auth, implemented by PDS." .
+<https://atproto.social/ontology/app.bsky.notification.putPreferences#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.putPreferences#Main> rdfs:comment "Set notification-related preferences for an account. Requires auth." .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestionsSkeleton#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestionsSkeleton#Main> rdfs:comment "Get a skeleton of suggested actors. Intended to be called and then hydrated through app.bsky.actor.getSuggestions" .
+<https://atproto.social/ontology/chat.bsky.convo.getConvo#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.revokeAppPassword#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.revokeAppPassword#Main> rdfs:comment "Revoke an App Password by name." .
+<https://atproto.social/ontology/app.bsky.actor.defs#LabelersPref> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#LabelersPref> rdfs:comment "ActorDefs_LabelersPref is a "labelersPref" in the app.bsky.actor.defs schema.
+
+RECORDTYPE: ActorDefs_LabelersPref" .
+<https://atproto.social/ontology/app.bsky.actor.defs#LabelersPref/labelers> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#LabelersPref/labelers> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#LabelersPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#LabelersPref/labelers> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#LabelerPrefItem> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated> rdfs:comment "ActorDefs_ProfileAssociated is a "profileAssociated" in the app.bsky.actor.defs schema." .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/feedgens> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/feedgens> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/feedgens> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/starterPacks> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/starterPacks> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/starterPacks> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/labeler> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/labeler> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/labeler> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/chat> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/chat> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/chat> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedChat> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/activitySubscription> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/activitySubscription> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/activitySubscription> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedActivitySubscription> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/lists> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/lists> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated/lists> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#ContentModeVideo> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ContentModeVideo> rdfs:comment "Declares the feed generator returns posts containing app.bsky.embed.video embeds." .
+<https://atproto.social/ontology/app.bsky.graph.searchStarterPacks#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.searchStarterPacks#Main> rdfs:comment "Find starter packs matching search criteria. Does not require auth." .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/did> rdfs:domain <https://atproto.social/ontology/tools.ozone.setting.defs#Option> .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/description> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/description> rdfs:domain <https://atproto.social/ontology/tools.ozone.setting.defs#Option> .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/description> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.setting.defs#Option> .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/managerRole> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/managerRole> rdfs:domain <https://atproto.social/ontology/tools.ozone.setting.defs#Option> .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/managerRole> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/key> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/key> rdfs:domain <https://atproto.social/ontology/tools.ozone.setting.defs#Option> .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/key> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/updatedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/updatedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.setting.defs#Option> .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/updatedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/scope> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/scope> rdfs:domain <https://atproto.social/ontology/tools.ozone.setting.defs#Option> .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/scope> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/createdBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/createdBy> rdfs:domain <https://atproto.social/ontology/tools.ozone.setting.defs#Option> .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/createdBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/lastUpdatedBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/lastUpdatedBy> rdfs:domain <https://atproto.social/ontology/tools.ozone.setting.defs#Option> .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/lastUpdatedBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/value> rdfs:domain <https://atproto.social/ontology/tools.ozone.setting.defs#Option> .
+<https://atproto.social/ontology/tools.ozone.setting.defs#Option/value> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic> rdfs:comment "GraphDefs_StarterPackViewBasic is a "starterPackViewBasic" in the app.bsky.graph.defs schema.
+
+RECORDTYPE: GraphDefs_StarterPackViewBasic" .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/record> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/record> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/record> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/creator> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/creator> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/creator> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#App.bsky.actor.defs#profileViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/listItemCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/listItemCount> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/listItemCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/labels> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/joinedWeekCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/joinedWeekCount> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/joinedWeekCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/joinedAllTimeCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/joinedAllTimeCount> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackViewBasic/joinedAllTimeCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Create> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Create> rdfs:comment "Operation which creates a new record." .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Create/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Create/value> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#Create> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Create/value> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Create/collection> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Create/collection> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#Create> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Create/collection> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Create/rkey> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Create/rkey> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#Create> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Create/rkey> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Create/rkey> rdfs:comment "NOTE: maxLength is redundant with record-key format. Keeping it temporarily to ensure backwards compatibility." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMute> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMute> rdfs:comment "Mute incoming reports on a subject" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMute/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMute/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMute> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMute/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMute/durationInHours> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMute/durationInHours> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMute> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMute/durationInHours> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventMute/durationInHours> rdfs:comment "Indicates how long the subject should remain muted." .
+<https://atproto.social/ontology/chat.bsky.convo.muteConvo#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.identity.getRecommendedDidCredentials#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.identity.getRecommendedDidCredentials#Main> rdfs:comment "Describe the credentials that should be included in the DID doc of an account that is migrating to this service." .
+<https://atproto.social/ontology/com.atproto.server.createInviteCodes#AccountCodes> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.createInviteCodes#AccountCodes/account> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.createInviteCodes#AccountCodes/account> rdfs:domain <https://atproto.social/ontology/com.atproto.server.createInviteCodes#AccountCodes> .
+<https://atproto.social/ontology/com.atproto.server.createInviteCodes#AccountCodes/account> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.createInviteCodes#AccountCodes/codes> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.createInviteCodes#AccountCodes/codes> rdfs:domain <https://atproto.social/ontology/com.atproto.server.createInviteCodes#AccountCodes> .
+<https://atproto.social/ontology/com.atproto.server.createInviteCodes#AccountCodes/codes> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#ThreadViewPref> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#ThreadViewPref> rdfs:comment "ActorDefs_ThreadViewPref is a "threadViewPref" in the app.bsky.actor.defs schema.
+
+RECORDTYPE: ActorDefs_ThreadViewPref" .
+<https://atproto.social/ontology/app.bsky.actor.defs#ThreadViewPref/sort> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ThreadViewPref/sort> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ThreadViewPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ThreadViewPref/sort> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ThreadViewPref/sort> rdfs:comment "sort: Sorting mode for threads." .
+<https://atproto.social/ontology/app.bsky.actor.defs#ThreadViewPref/prioritizeFollowedUsers> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ThreadViewPref/prioritizeFollowedUsers> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ThreadViewPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ThreadViewPref/prioritizeFollowedUsers> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.actor.defs#ThreadViewPref/prioritizeFollowedUsers> rdfs:comment "prioritizeFollowedUsers: Show followed users at the top of all replies." .
+<https://atproto.social/ontology/app.bsky.graph.list#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.list#Main> rdfs:comment "Record representing a list of accounts (actors). Scope includes both moderation-oriented lists and curration-oriented lists." .
+<https://atproto.social/ontology/app.bsky.video.uploadVideo#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.video.uploadVideo#Main> rdfs:comment "Upload a video to be processed then stored on the PDS." .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageAndReactionView> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageAndReactionView/message> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageAndReactionView/message> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageAndReactionView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageAndReactionView/message> rdfs:range <https://atproto.social/ontology/chat.bsky.convo.defs#MessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageAndReactionView/reaction> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageAndReactionView/reaction> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageAndReactionView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageAndReactionView/reaction> rdfs:range <https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView> .
+<https://atproto.social/ontology/app.bsky.embed.record#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.record#Main/record> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#Main/record> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#Main> .
+<https://atproto.social/ontology/app.bsky.embed.record#Main/record> rdfs:range <https://atproto.social/ontology/app.bsky.embed.record#Com.atproto.repo.strongRef> .
+<https://atproto.social/ontology/app.bsky.graph.defs#Curatelist> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.defs#Curatelist> rdfs:comment "A list of actors used for curation purposes such as list feeds or interaction gating." .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestedUsersSkeleton#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestedUsersSkeleton#Main> rdfs:comment "Get a skeleton of suggested users. Intended to be called and hydrated by app.bsky.unspecced.getSuggestedUsers" .
+<https://atproto.social/ontology/app.bsky.embed.video#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/video> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/video> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.video#Main> .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/video> rdfs:range xsd:base64Binary .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/video> rdfs:comment "The mp4 video file. May be up to 100mb, formerly limited to 50mb." .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/captions> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/captions> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.video#Main> .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/captions> rdfs:range <https://atproto.social/ontology/app.bsky.embed.video#Caption> .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/alt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/alt> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.video#Main> .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/alt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/alt> rdfs:comment "Alt text description of the video, for accessibility." .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/aspectRatio> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/aspectRatio> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.video#Main> .
+<https://atproto.social/ontology/app.bsky.embed.video#Main/aspectRatio> rdfs:range <https://atproto.social/ontology/app.bsky.embed.video#App.bsky.embed.defs#aspectRatio> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage/convoId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage/convoId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage/convoId> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage/message> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage/message> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage/message> rdfs:range owl:Thing .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogCreateMessage/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef/did> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef/convoId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef/convoId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef/convoId> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef/messageId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef/messageId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageRef/messageId> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventResolveAppeal> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventResolveAppeal> rdfs:comment "Resolve appeal on a subject" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventResolveAppeal/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventResolveAppeal/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventResolveAppeal> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventResolveAppeal/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventResolveAppeal/comment> rdfs:comment "Describe resolution." .
+<https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#Main> rdfs:comment "Revoke previously granted verifications in batches of up to 100." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemNotFound> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemNotFound> rdfs:comment "UnspeccedDefs_ThreadItemNotFound is a "threadItemNotFound" in the app.bsky.unspecced.defs schema.
+
+RECORDTYPE: UnspeccedDefs_ThreadItemNotFound" .
+<https://atproto.social/ontology/com.atproto.server.deleteSession#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.deleteSession#Main> rdfs:comment "Delete the current session. Requires auth." .
+<https://atproto.social/ontology/com.atproto.sync.listReposByCollection#Repo> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.listReposByCollection#Repo/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.listReposByCollection#Repo/did> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.listReposByCollection#Repo> .
+<https://atproto.social/ontology/com.atproto.sync.listReposByCollection#Repo/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.setting.removeOptions#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.setting.removeOptions#Main> rdfs:comment "Delete settings by key" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModerationDetail> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModerationDetail/subjectStatus> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModerationDetail/subjectStatus> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModerationDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModerationDetail/subjectStatus> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/app.bsky.notification.putActivitySubscription#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.putActivitySubscription#Main> rdfs:comment "Puts an activity subscription entry. The key should be omitted for creation and provided for updates. Requires auth." .
+<https://atproto.social/ontology/com.atproto.repo.listRecords#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.listRecords#Main> rdfs:comment "List a range of records in a repository, matching a specific collection. Does not require auth." .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Main> rdfs:comment "Describes the server's account creation requirements and capabilities. Implemented by PDS." .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Main> rdfs:comment "Get account history, e.g. log of updated email addresses or other identity information." .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestedFeedsSkeleton#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestedFeedsSkeleton#Main> rdfs:comment "Get a skeleton of suggested feeds. Intended to be called and hydrated by app.bsky.unspecced.getSuggestedFeeds" .
+<https://atproto.social/ontology/tools.ozone.set.getValues#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.set.getValues#Main> rdfs:comment "Get a specific set and its values" .
+<https://atproto.social/ontology/app.bsky.notification.getUnreadCount#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.getUnreadCount#Main> rdfs:comment "Count the number of unread notifications for the requesting account. Requires auth." .
+<https://atproto.social/ontology/chat.bsky.convo.leaveConvo#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.sendEmail#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.sendEmail#Main> rdfs:comment "Send email to a user's account email address." .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/subject> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/subject> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput> .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/subject> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/subject> rdfs:comment "The did of the subject being verified" .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/handle> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput> .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/handle> rdfs:comment "Handle of the subject the verification applies to at the moment of verifying." .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/displayName> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/displayName> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput> .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/displayName> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/displayName> rdfs:comment "Display name of the subject the verification applies to at the moment of verifying." .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput> .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#VerificationInput/createdAt> rdfs:comment "Timestamp for verification record. Defaults to current time when not specified." .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Link> a owl:Class .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Link> rdfs:comment "RichtextFacet_Link is a "link" in the app.bsky.richtext.facet schema.
+
+Facet feature for a URL. The text URL may have been simplified or truncated, but the facet reference should be a complete URL.
+
+RECORDTYPE: RichtextFacet_Link" .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Link/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Link/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.richtext.facet#Link> .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Link/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.getConfig#LiveNowConfig> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getConfig#LiveNowConfig> rdfs:comment "UnspeccedGetConfig_LiveNowConfig is a "liveNowConfig" in the app.bsky.unspecced.getConfig schema." .
+<https://atproto.social/ontology/app.bsky.unspecced.getConfig#LiveNowConfig/domains> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.getConfig#LiveNowConfig/domains> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.getConfig#LiveNowConfig> .
+<https://atproto.social/ontology/app.bsky.unspecced.getConfig#LiveNowConfig/domains> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.unspecced.getConfig#LiveNowConfig/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.getConfig#LiveNowConfig/did> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.getConfig#LiveNowConfig> .
+<https://atproto.social/ontology/app.bsky.unspecced.getConfig#LiveNowConfig/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage/convoId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage/convoId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage/convoId> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage/message> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage/message> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage/message> rdfs:range owl:Thing .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogReadMessage/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogLeaveConvo> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogLeaveConvo/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogLeaveConvo/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogLeaveConvo> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogLeaveConvo/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogLeaveConvo/convoId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogLeaveConvo/convoId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogLeaveConvo> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogLeaveConvo/convoId> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.getSession#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.getSession#Main> rdfs:comment "Get information about the current auth session. Requires auth." .
+<https://atproto.social/ontology/app.bsky.actor.status#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.status#Main> rdfs:comment "A declaration of a Bluesky account status." .
+<https://atproto.social/ontology/app.bsky.notification.defs#ChatPreference> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.defs#ChatPreference> rdfs:comment "NotificationDefs_ChatPreference is a "chatPreference" in the app.bsky.notification.defs schema." .
+<https://atproto.social/ontology/app.bsky.notification.defs#ChatPreference/include> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#ChatPreference/include> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#ChatPreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#ChatPreference/include> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.notification.defs#ChatPreference/push> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#ChatPreference/push> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#ChatPreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#ChatPreference/push> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.unspecced.searchPostsSkeleton#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.searchPostsSkeleton#Main> rdfs:comment "Backend Posts search, returns only skeleton" .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword/name> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword/name> rdfs:domain <https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword> .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword/name> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword/password> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword/password> rdfs:domain <https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword> .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword/password> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword/createdAt> rdfs:domain <https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword> .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword/privileged> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword/privileged> rdfs:domain <https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword> .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#AppPassword/privileged> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Main> rdfs:comment "Get a list of suggestions (feeds and users) tagged with categories" .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonSpam> a owl:Class .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonSpam> rdfs:comment "Spam: frequent unwanted promotion, replies, mentions" .
+<https://atproto.social/ontology/com.atproto.server.deactivateAccount#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.deactivateAccount#Main> rdfs:comment "Deactivates a currently active account. Stops serving of repo, and future writes to repo until reactivated. Used to finalize account migration with the old host after the account has been activated on the new host." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel> rdfs:comment "Apply/Negate labels on a subject" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/createLabelVals> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/createLabelVals> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/createLabelVals> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/negateLabelVals> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/negateLabelVals> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/negateLabelVals> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/durationInHours> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/durationInHours> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/durationInHours> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventLabel/durationInHours> rdfs:comment "Indicates how long the label will remain on the subject. Only applies on labels that are being added." .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> rdfs:comment "ActorDefs_ProfileViewDetailed is a "profileViewDetailed" in the app.bsky.actor.defs schema." .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/displayName> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/displayName> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/displayName> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/banner> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/banner> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/banner> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/joinedViaStarterPack> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/joinedViaStarterPack> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/joinedViaStarterPack> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#App.bsky.graph.defs#starterPackViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/verification> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/verification> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/verification> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#VerificationState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/status> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/status> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/status> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#StatusView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/did> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/description> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/description> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/description> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/avatar> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/avatar> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/avatar> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/followsCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/followsCount> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/followsCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/createdAt> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/viewer> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/viewer> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/viewer> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/pinnedPost> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/pinnedPost> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/pinnedPost> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#Com.atproto.repo.strongRef> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/handle> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/postsCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/postsCount> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/postsCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/labels> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/followersCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/followersCount> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/followersCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/associated> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/associated> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewDetailed/associated> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedActivitySubscription> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedActivitySubscription> rdfs:comment "ActorDefs_ProfileAssociatedActivitySubscription is a "profileAssociatedActivitySubscription" in the app.bsky.actor.defs schema." .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedActivitySubscription/allowSubscriptions> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedActivitySubscription/allowSubscriptions> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedActivitySubscription> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedActivitySubscription/allowSubscriptions> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.searchActorsTypeahead#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.searchActorsTypeahead#Main> rdfs:comment "Find actor suggestions for a prefix search term. Expected use is for auto-completion during text field entry. Does not require auth." .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListPurpose> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.team.deleteMember#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.team.deleteMember#Main> rdfs:comment "Delete a member from ozone team. Requires admin role." .
+<https://atproto.social/ontology/app.bsky.actor.defs#Preferences> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Delete> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Delete> rdfs:comment "Operation which deletes an existing record." .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Delete/collection> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Delete/collection> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#Delete> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Delete/collection> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Delete/rkey> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Delete/rkey> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#Delete> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Delete/rkey> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationPrefs> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationPrefs> rdfs:comment "ActorDefs_VerificationPrefs is a "verificationPrefs" in the app.bsky.actor.defs schema.
+
+Preferences for how verified accounts appear in the app.
+
+RECORDTYPE: ActorDefs_VerificationPrefs" .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationPrefs/hideBadges> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationPrefs/hideBadges> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#VerificationPrefs> .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationPrefs/hideBadges> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.actor.defs#VerificationPrefs/hideBadges> rdfs:comment "hideBadges: Hide the blue check badges for verified accounts and trusted verifiers." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity> rdfs:comment "Represents a change to an account's identity. Could be an updated handle, signing key, or pds hosting endpoint. Serves as a prod to all downstream services to refresh their identity cache." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/seq> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/seq> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/seq> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/did> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/time> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/time> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/time> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/handle> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Identity/handle> rdfs:comment "The current handle for the account, or 'handle.invalid' if validation fails. This field is optional, might have been validated or passed-through from an upstream source. Semantics and behaviors for PDS vs Relay may evolve in the future; see atproto specs for more details." .
+<https://atproto.social/ontology/com.atproto.admin.getAccountInfo#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.getAccountInfo#Main> rdfs:comment "Get details about an account." .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonRude> a owl:Class .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonRude> rdfs:comment "Rude, harassing, explicit, or otherwise unwelcoming behavior" .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/code> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/code> rdfs:domain <https://atproto.social/ontology/com.atproto.server.defs#InviteCode> .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/code> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/available> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/available> rdfs:domain <https://atproto.social/ontology/com.atproto.server.defs#InviteCode> .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/available> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/disabled> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/disabled> rdfs:domain <https://atproto.social/ontology/com.atproto.server.defs#InviteCode> .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/disabled> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/forAccount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/forAccount> rdfs:domain <https://atproto.social/ontology/com.atproto.server.defs#InviteCode> .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/forAccount> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/createdBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/createdBy> rdfs:domain <https://atproto.social/ontology/com.atproto.server.defs#InviteCode> .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/createdBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/createdAt> rdfs:domain <https://atproto.social/ontology/com.atproto.server.defs#InviteCode> .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/uses> a owl:ObjectProperty .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/uses> rdfs:domain <https://atproto.social/ontology/com.atproto.server.defs#InviteCode> .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCode/uses> rdfs:range <https://atproto.social/ontology/com.atproto.server.defs#InviteCodeUse> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/id> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/id> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/id> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/event> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/event> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/event> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/subject> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/subject> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/subject> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/subjectBlobCids> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/subjectBlobCids> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/subjectBlobCids> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/createdBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/createdBy> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/createdBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/creatorHandle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/creatorHandle> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/creatorHandle> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/subjectHandle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/subjectHandle> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventView/subjectHandle> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#AdultContentPref> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#AdultContentPref> rdfs:comment "ActorDefs_AdultContentPref is a "adultContentPref" in the app.bsky.actor.defs schema.
+
+RECORDTYPE: ActorDefs_AdultContentPref" .
+<https://atproto.social/ontology/app.bsky.actor.defs#AdultContentPref/enabled> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#AdultContentPref/enabled> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#AdultContentPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#AdultContentPref/enabled> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.graph.getKnownFollowers#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getKnownFollowers#Main> rdfs:comment "Enumerates accounts which follow a specified account (actor) and are followed by the viewer." .
+<https://atproto.social/ontology/app.bsky.graph.getListMutes#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getListMutes#Main> rdfs:comment "Enumerates mod lists that the requesting account (actor) currently has muted. Requires auth." .
+<https://atproto.social/ontology/app.bsky.graph.unmuteActorList#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.unmuteActorList#Main> rdfs:comment "Unmutes the specified list of accounts. Requires auth." .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed> rdfs:comment "ActorDefs_SavedFeed is a "savedFeed" in the app.bsky.actor.defs schema." .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed/id> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed/id> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed/id> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed/type> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed/type> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed/type> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed/value> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed/value> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed/pinned> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed/pinned> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed> .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeed/pinned> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.notification.defs#ActivitySubscription> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.defs#ActivitySubscription> rdfs:comment "NotificationDefs_ActivitySubscription is a "activitySubscription" in the app.bsky.notification.defs schema." .
+<https://atproto.social/ontology/app.bsky.notification.defs#ActivitySubscription/post> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#ActivitySubscription/post> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#ActivitySubscription> .
+<https://atproto.social/ontology/app.bsky.notification.defs#ActivitySubscription/post> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.notification.defs#ActivitySubscription/reply> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#ActivitySubscription/reply> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#ActivitySubscription> .
+<https://atproto.social/ontology/app.bsky.notification.defs#ActivitySubscription/reply> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/com.atproto.sync.getRepoStatus#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.getRepoStatus#Main> rdfs:comment "Get the hosting status for a repository, on this server. Expected to be implemented by PDS and Relay." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> rdfs:comment "Represents an update of repository state. Note that empty commits are allowed, which include no repo data changes, but an update to rev and signature." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/blobs> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/blobs> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/blobs> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/prevData> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/prevData> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/prevData> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/prevData> rdfs:comment "The root CID of the MST tree for the previous commit from this repo (indicated by the 'since' revision field in this message). Corresponds to the 'data' field in the repo commit object. NOTE: this field is effectively required for the 'inductive' version of firehose." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/time> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/time> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/time> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/time> rdfs:comment "Timestamp of when this message was originally broadcast." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/tooBig> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/tooBig> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/tooBig> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/tooBig> rdfs:comment "DEPRECATED -- replaced by #sync event and data limits. Indicates that this commit contained too many ops, or data size was too large. Consumers will need to make a separate request to get missing data." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/since> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/since> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/since> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/since> rdfs:comment "The rev of the last emitted commit from this repo (if any)." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/blocks> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/blocks> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/blocks> rdfs:range xsd:base64Binary .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/blocks> rdfs:comment "CAR file containing relevant blocks, as a diff since the previous repo state. The commit must be included as a block, and the commit block CID must be the first entry in the CAR header 'roots' list." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/ops> a owl:ObjectProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/ops> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/ops> rdfs:range <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/rev> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/rev> rdfs:comment "The rev of the emitted commit. Note that this information is also in the commit object included in blocks, unless this is a tooBig event." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/seq> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/seq> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/seq> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/seq> rdfs:comment "The stream sequence number of this message." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/rebase> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/rebase> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/rebase> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/rebase> rdfs:comment "DEPRECATED -- unused" .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/repo> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/repo> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/repo> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/repo> rdfs:comment "The repo this event comes from. Note that all other message types name this field 'did'." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/commit> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/commit> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/commit> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Commit/commit> rdfs:comment "Repo commit object CID." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend> rdfs:comment "UnspeccedDefs_SkeletonTrend is a "skeletonTrend" in the app.bsky.unspecced.defs schema." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/status> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/status> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/status> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/category> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/category> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/category> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/dids> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/dids> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/dids> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/topic> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/topic> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/topic> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/displayName> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/displayName> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/displayName> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/link> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/link> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/link> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/startedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/startedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/startedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/postCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/postCount> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonTrend/postCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.repo.listRecords#Record> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.listRecords#Record/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.listRecords#Record/cid> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.listRecords#Record> .
+<https://atproto.social/ontology/com.atproto.repo.listRecords#Record/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.listRecords#Record/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.listRecords#Record/value> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.listRecords#Record> .
+<https://atproto.social/ontology/com.atproto.repo.listRecords#Record/value> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.repo.listRecords#Record/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.listRecords#Record/uri> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.listRecords#Record> .
+<https://atproto.social/ontology/com.atproto.repo.listRecords#Record/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction/convoId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction/convoId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction/convoId> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction/message> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction/message> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction/message> rdfs:range owl:Thing .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction/reaction> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction/reaction> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogRemoveReaction/reaction> rdfs:range <https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView> .
+<https://atproto.social/ontology/tools.ozone.communication.listTemplates#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.communication.listTemplates#Main> rdfs:comment "Get list of all communication templates." .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedChat> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedChat> rdfs:comment "ActorDefs_ProfileAssociatedChat is a "profileAssociatedChat" in the app.bsky.actor.defs schema." .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedChat/allowIncoming> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedChat/allowIncoming> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedChat> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociatedChat/allowIncoming> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.record#View> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.record#View> rdfs:comment "EmbedRecord_View is a "view" in the app.bsky.embed.record schema.
+
+RECORDTYPE: EmbedRecord_View" .
+<https://atproto.social/ontology/app.bsky.embed.record#View/record> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#View/record> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#View> .
+<https://atproto.social/ontology/app.bsky.embed.record#View/record> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.searchPosts#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.searchPosts#Main> rdfs:comment "Find posts matching search criteria, returning views of those posts. Note that this API endpoint may require authentication (eg, not public) for some service providers and implementations." .
+<https://atproto.social/ontology/app.bsky.video.getJobStatus#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.video.getJobStatus#Main> rdfs:comment "Get status details for a video processing job." .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic> rdfs:comment "ActorDefs_ProfileViewBasic is a "profileViewBasic" in the app.bsky.actor.defs schema." .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/viewer> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/viewer> rdfs:domain <https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/viewer> rdfs:range <https://atproto.social/ontology/chat.bsky.actor.defs#App.bsky.actor.defs#viewerState> .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/did> rdfs:domain <https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/handle> rdfs:domain <https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/displayName> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/displayName> rdfs:domain <https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/displayName> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/avatar> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/avatar> rdfs:domain <https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/avatar> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/associated> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/associated> rdfs:domain <https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/associated> rdfs:range <https://atproto.social/ontology/chat.bsky.actor.defs#App.bsky.actor.defs#profileAssociated> .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/labels> rdfs:domain <https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/labels> rdfs:range <https://atproto.social/ontology/chat.bsky.actor.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/chatDisabled> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/chatDisabled> rdfs:domain <https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/chatDisabled> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/chatDisabled> rdfs:comment "Set to true when the actor cannot actively participate in conversations" .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/verification> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/verification> rdfs:domain <https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/chat.bsky.actor.defs#ProfileViewBasic/verification> rdfs:range <https://atproto.social/ontology/chat.bsky.actor.defs#App.bsky.actor.defs#verificationState> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#Moderation> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#Moderation/subjectStatus> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#Moderation/subjectStatus> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#Moderation> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#Moderation/subjectStatus> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppProgressGuide> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppProgressGuide> rdfs:comment "ActorDefs_BskyAppProgressGuide is a "bskyAppProgressGuide" in the app.bsky.actor.defs schema.
+
+If set, an active progress guide. Once completed, can be set to undefined. Should have unspecced fields tracking progress." .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppProgressGuide/guide> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppProgressGuide/guide> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#BskyAppProgressGuide> .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppProgressGuide/guide> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/subjectBlobCids> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/subjectBlobCids> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/subjectBlobCids> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/createdAt> rdfs:comment "Timestamp referencing the first moderation status impacting event was emitted on the subject" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastReviewedBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastReviewedBy> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastReviewedBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/suspendUntil> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/suspendUntil> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/suspendUntil> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/accountStats> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/accountStats> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/accountStats> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/accountStats> rdfs:comment "Statistics related to the account subject" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/recordsStats> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/recordsStats> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/recordsStats> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/recordsStats> rdfs:comment "Statistics related to the record subjects authored by the subject's account" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/comment> rdfs:comment "Sticky comment on the subject." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/muteUntil> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/muteUntil> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/muteUntil> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastReportedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastReportedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastReportedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastAppealedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastAppealedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastAppealedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastAppealedAt> rdfs:comment "Timestamp referencing when the author of the subject appealed a moderation action" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/appealed> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/appealed> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/appealed> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/appealed> rdfs:comment "True indicates that the a previously taken moderator action was appealed against, by the author of the content. False indicates last appeal was resolved by moderators." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/id> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/id> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/id> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/subject> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/subject> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/subject> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/hosting> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/hosting> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/hosting> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/subjectRepoHandle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/subjectRepoHandle> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/subjectRepoHandle> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/updatedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/updatedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/updatedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/updatedAt> rdfs:comment "Timestamp referencing when the last update was made to the moderation status of the subject" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/reviewState> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/reviewState> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/reviewState> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectReviewState> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/priorityScore> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/priorityScore> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/priorityScore> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/priorityScore> rdfs:comment "Numeric value representing the level of priority. Higher score means higher priority." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/muteReportingUntil> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/muteReportingUntil> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/muteReportingUntil> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastReviewedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastReviewedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/lastReviewedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/takendown> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/takendown> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/takendown> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/tags> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/tags> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView/tags> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.getRepo#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.getRepo#Main> rdfs:comment "Get details about a repository." .
+<https://atproto.social/ontology/app.bsky.feed.defs#ClickthroughEmbed> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ClickthroughEmbed> rdfs:comment "User clicked through to the embedded content of the feed item" .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult/uri> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult/cid> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult/validationStatus> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult/validationStatus> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#CreateResult/validationStatus> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats> rdfs:comment "Statistics about a particular account subject" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/suspendCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/suspendCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/suspendCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/suspendCount> rdfs:comment "Number of times the account was suspended" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/escalateCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/escalateCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/escalateCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/escalateCount> rdfs:comment "Number of times the account was escalated" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/takedownCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/takedownCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/takedownCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/takedownCount> rdfs:comment "Number of times the account was taken down" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/reportCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/reportCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/reportCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/reportCount> rdfs:comment "Total number of reports on the account" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/appealCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/appealCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/appealCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountStats/appealCount> rdfs:comment "Total number of appeals against a moderation action on the account" .
+<https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref> rdfs:comment "ActorDefs_ContentLabelPref is a "contentLabelPref" in the app.bsky.actor.defs schema.
+
+RECORDTYPE: ActorDefs_ContentLabelPref" .
+<https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref/labelerDid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref/labelerDid> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref/labelerDid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref/labelerDid> rdfs:comment "labelerDid: Which labeler does this preference apply to? If undefined, applies globally." .
+<https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref/label> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref/label> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref/label> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref/visibility> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref/visibility> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ContentLabelPref/visibility> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#Main/record> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#Main/record> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.recordWithMedia#Main> .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#Main/record> rdfs:range <https://atproto.social/ontology/app.bsky.embed.recordWithMedia#App.bsky.embed.record> .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#Main/media> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#Main/media> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.recordWithMedia#Main> .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#Main/media> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.sendInteractions#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.sendInteractions#Main> rdfs:comment "Send information about interactions with feed items back to the feed generator that served them." .
+<https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#RelatedAccount> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#RelatedAccount/similarities> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#RelatedAccount/similarities> rdfs:domain <https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#RelatedAccount> .
+<https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#RelatedAccount/similarities> rdfs:range <https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#Tools.ozone.signature.defs#sigDetail> .
+<https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#RelatedAccount/account> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#RelatedAccount/account> rdfs:domain <https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#RelatedAccount> .
+<https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#RelatedAccount/account> rdfs:range <https://atproto.social/ontology/tools.ozone.signature.findRelatedAccounts#Com.atproto.admin.defs#accountView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#RequestMore> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#RequestMore> rdfs:comment "Request that more content like the given feed item be shown in the feed" .
+<https://atproto.social/ontology/chat.bsky.moderation.updateActorAccess#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonSexual> a owl:Class .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonSexual> rdfs:comment "Unwanted or mislabeled sexual content" .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Info> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Info/name> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Info/name> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Info> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Info/name> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Info/message> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Info/message> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Info> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Info/message> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView> rdfs:comment "FeedDefs_ThreadgateView is a "threadgateView" in the app.bsky.feed.defs schema." .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView/record> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView/record> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView/record> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView/lists> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView/lists> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView/lists> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#App.bsky.graph.defs#listViewBasic> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadContext> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadContext> rdfs:comment "FeedDefs_ThreadContext is a "threadContext" in the app.bsky.feed.defs schema.
+
+Metadata about this post within the context of the thread it is in." .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadContext/rootAuthorLike> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadContext/rootAuthorLike> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ThreadContext> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ThreadContext/rootAuthorLike> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preference> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preference> rdfs:comment "NotificationDefs_Preference is a "preference" in the app.bsky.notification.defs schema." .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preference/list> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preference/list> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preference/list> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preference/push> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preference/push> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preference/push> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/com.atproto.server.requestEmailUpdate#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.requestEmailUpdate#Main> rdfs:comment "Request a token in order to update email." .
+<https://atproto.social/ontology/com.atproto.sync.getRecord#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.getRecord#Main> rdfs:comment "Get data blocks needed to prove the existence or non-existence of record in the current version of repo. Does not require auth." .
+<https://atproto.social/ontology/app.bsky.feed.defs#InteractionRepost> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#InteractionRepost> rdfs:comment "User reposted the feed item" .
+<https://atproto.social/ontology/app.bsky.feed.getPosts#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getPosts#Main> rdfs:comment "Gets post views for a specified list of posts (by AT-URI). This is sometimes referred to as 'hydrating' a 'feed skeleton'." .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences> rdfs:comment "NotificationDefs_Preferences is a "preferences" in the app.bsky.notification.defs schema." .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/quote> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/quote> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/quote> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/reply> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/reply> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/reply> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/subscribedPost> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/subscribedPost> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/subscribedPost> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#Preference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/likeViaRepost> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/likeViaRepost> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/likeViaRepost> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/follow> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/follow> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/follow> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/like> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/like> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/like> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/mention> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/mention> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/mention> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/repost> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/repost> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/repost> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/repostViaRepost> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/repostViaRepost> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/repostViaRepost> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/starterpackJoined> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/starterpackJoined> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/starterpackJoined> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#Preference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/unverified> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/unverified> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/unverified> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#Preference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/chat> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/chat> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/chat> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#ChatPreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/verified> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/verified> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#Preferences> .
+<https://atproto.social/ontology/app.bsky.notification.defs#Preferences/verified> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#Preference> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView/value> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView/value> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView/sender> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView/sender> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView/sender> rdfs:range <https://atproto.social/ontology/chat.bsky.convo.defs#ReactionViewSender> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView/createdAt> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.notification.declaration#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.declaration#Main> rdfs:comment "A declaration of the user's choices related to notifications that can be produced by them." .
+<https://atproto.social/ontology/chat.bsky.actor.exportAccountData#Main> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.updateRead#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.deleteAccount#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.deleteAccount#Main> rdfs:comment "Delete an actor's account with a token and password. Can only be called after requesting a deletion token. Requires auth." .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorViewerState> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorViewerState> rdfs:comment "FeedDefs_GeneratorViewerState is a "generatorViewerState" in the app.bsky.feed.defs schema." .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorViewerState/like> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorViewerState/like> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#GeneratorViewerState> .
+<https://atproto.social/ontology/app.bsky.feed.defs#GeneratorViewerState/like> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#FollowerRule> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#FollowerRule> rdfs:comment "FeedThreadgate_FollowerRule is a "followerRule" in the app.bsky.feed.threadgate schema.
+
+Allow replies from actors who follow you.
+
+RECORDTYPE: FeedThreadgate_FollowerRule" .
+<https://atproto.social/ontology/app.bsky.graph.getStarterPack#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getStarterPack#Main> rdfs:comment "Gets a view of a starter pack." .
+<https://atproto.social/ontology/app.bsky.graph.muteActorList#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.muteActorList#Main> rdfs:comment "Creates a mute relationship for the specified list of accounts. Mutes are private in Bluesky. Requires auth." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmuteReporter> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmuteReporter> rdfs:comment "Unmute incoming reports from an account" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmuteReporter/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmuteReporter/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmuteReporter> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmuteReporter/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmuteReporter/comment> rdfs:comment "Describe reasoning behind the reversal." .
+<https://atproto.social/ontology/chat.bsky.convo.getConvoAvailability#Main> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.getConvoAvailability#Main> rdfs:comment "Get whether the requester and the other members can chat. If an existing convo is found for these members, it is returned." .
+<https://atproto.social/ontology/com.atproto.sync.listBlobs#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.listBlobs#Main> rdfs:comment "List blob CIDs for an account, since some repo revision. Does not require auth; implemented by PDS." .
+<https://atproto.social/ontology/com.atproto.temp.requestPhoneVerification#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.temp.requestPhoneVerification#Main> rdfs:comment "Request a verification code to be sent to the supplied phone number" .
+<https://atproto.social/ontology/app.bsky.feed.defs#NotFoundPost> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#NotFoundPost> rdfs:comment "FeedDefs_NotFoundPost is a "notFoundPost" in the app.bsky.feed.defs schema.
+
+RECORDTYPE: FeedDefs_NotFoundPost" .
+<https://atproto.social/ontology/app.bsky.feed.defs#NotFoundPost/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#NotFoundPost/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#NotFoundPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#NotFoundPost/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#NotFoundPost/notFound> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#NotFoundPost/notFound> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#NotFoundPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#NotFoundPost/notFound> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.feed.getTimeline#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getTimeline#Main> rdfs:comment "Get a view of the requesting account's home timeline. This is expected to be some form of reverse-chronological feed." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchPost> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchPost> rdfs:comment "UnspeccedDefs_SkeletonSearchPost is a "skeletonSearchPost" in the app.bsky.unspecced.defs schema." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchPost/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchPost/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchPost> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchPost/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.getCheckout#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.getCheckout#Main> rdfs:comment "DEPRECATED - please use com.atproto.sync.getRepo instead" .
+<https://atproto.social/ontology/app.bsky.feed.defs#InteractionLike> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#InteractionLike> rdfs:comment "User liked the feed item" .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#Main> rdfs:comment "(NOTE: this endpoint is under development and WILL change without notice. Don't use it until it is moved out of `unspecced` or your application WILL break) Get additional posts under a thread e.g. replies hidden by threadgate. Based on an anchor post at any depth of the tree, returns top-level replies below that anchor. It does not include ancestors nor the anchor itself. This should be called after exhausting `app.bsky.unspecced.getPostThreadV2`. Does not require auth, but additional metadata and filtering will be applied for authed requests." .
+<https://atproto.social/ontology/com.atproto.admin.searchAccounts#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.searchAccounts#Main> rdfs:comment "Get list of accounts that matches your search query." .
+<https://atproto.social/ontology/tools.ozone.setting.upsertOption#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.setting.upsertOption#Main> rdfs:comment "Create or update setting option" .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPrefV2> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPrefV2> rdfs:comment "ActorDefs_SavedFeedsPrefV2 is a "savedFeedsPrefV2" in the app.bsky.actor.defs schema.
+
+RECORDTYPE: ActorDefs_SavedFeedsPrefV2" .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPrefV2/items> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPrefV2/items> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPrefV2> .
+<https://atproto.social/ontology/app.bsky.actor.defs#SavedFeedsPrefV2/items> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#App.bsky.actor.defs#savedFeed> .
+<https://atproto.social/ontology/app.bsky.embed.video#Caption> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.video#Caption> rdfs:comment "EmbedVideo_Caption is a "caption" in the app.bsky.embed.video schema." .
+<https://atproto.social/ontology/app.bsky.embed.video#Caption/lang> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.video#Caption/lang> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.video#Caption> .
+<https://atproto.social/ontology/app.bsky.embed.video#Caption/lang> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.video#Caption/file> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.video#Caption/file> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.video#Caption> .
+<https://atproto.social/ontology/app.bsky.embed.video#Caption/file> rdfs:range xsd:base64Binary .
+<https://atproto.social/ontology/com.atproto.admin.updateAccountPassword#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.updateAccountPassword#Main> rdfs:comment "Update the password for a user account as an administrator." .
+<https://atproto.social/ontology/tools.ozone.communication.createTemplate#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.communication.createTemplate#Main> rdfs:comment "Administrative action to create a new, re-usable communication (email for now) template." .
+<https://atproto.social/ontology/app.bsky.actor.defs#InterestsPref> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#InterestsPref> rdfs:comment "ActorDefs_InterestsPref is a "interestsPref" in the app.bsky.actor.defs schema.
+
+RECORDTYPE: ActorDefs_InterestsPref" .
+<https://atproto.social/ontology/app.bsky.actor.defs#InterestsPref/tags> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#InterestsPref/tags> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#InterestsPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#InterestsPref/tags> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#InterestsPref/tags> rdfs:comment "tags: A list of tags which describe the account owner's interests gathered during onboarding." .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic> rdfs:comment "GraphDefs_ListViewBasic is a "listViewBasic" in the app.bsky.graph.defs schema." .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/name> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/name> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/name> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/purpose> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/purpose> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/purpose> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#ListPurpose> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/avatar> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/avatar> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/avatar> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/labels> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/listItemCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/listItemCount> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/listItemCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/viewer> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/viewer> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/viewer> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#ListViewerState> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.labeler.getServices#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.labeler.getServices#Main> rdfs:comment "Get information about a list of labeler services." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails/length> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails/length> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails/length> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails/width> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails/width> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails/width> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails/height> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails/height> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#VideoDetails/height> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestedUsers#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestedUsers#Main> rdfs:comment "Get a list of suggested users" .
+<https://atproto.social/ontology/tools.ozone.set.querySets#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.set.querySets#Main> rdfs:comment "Query available sets" .
+<https://atproto.social/ontology/com.atproto.repo.getRecord#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.getRecord#Main> rdfs:comment "Get a single record from a repository. Does not require auth." .
+<https://atproto.social/ontology/tools.ozone.team.listMembers#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.team.listMembers#Main> rdfs:comment "List all members with access to the ozone service." .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Main> rdfs:comment "Get like records which reference a subject (by AT-URI and CID)." .
+<https://atproto.social/ontology/app.bsky.graph.getListBlocks#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getListBlocks#Main> rdfs:comment "Get mod lists that the requesting account (actor) is blocking. Requires auth." .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion> rdfs:comment "UnspeccedGetTaggedSuggestions_Suggestion is a "suggestion" in the app.bsky.unspecced.getTaggedSuggestions schema." .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion/tag> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion/tag> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion> .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion/tag> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion/subjectType> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion/subjectType> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion> .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion/subjectType> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion/subject> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion/subject> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion> .
+<https://atproto.social/ontology/app.bsky.unspecced.getTaggedSuggestions#Suggestion/subject> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.admin.getAccountInfos#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.getAccountInfos#Main> rdfs:comment "Get details about some accounts." .
+<https://atproto.social/ontology/chat.bsky.convo.getConvoForMembers#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.defs#ThreatSignature> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.defs#ThreatSignature/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#ThreatSignature/value> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#ThreatSignature> .
+<https://atproto.social/ontology/com.atproto.admin.defs#ThreatSignature/value> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.admin.defs#ThreatSignature/property> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#ThreatSignature/property> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#ThreatSignature> .
+<https://atproto.social/ontology/com.atproto.admin.defs#ThreatSignature/property> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.getServiceAuth#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.getServiceAuth#Main> rdfs:comment "Get a signed token on behalf of the requesting DID for the requested service." .
+<https://atproto.social/ontology/app.bsky.embed.external#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.external#Main> rdfs:comment "A representation of some externally linked content (eg, a URL and 'card'), embedded in a Bluesky record (eg, a post)." .
+<https://atproto.social/ontology/app.bsky.embed.external#Main/external> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.external#Main/external> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.external#Main> .
+<https://atproto.social/ontology/app.bsky.embed.external#Main/external> rdfs:range <https://atproto.social/ontology/app.bsky.embed.external#External> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail> rdfs:comment "Keep a log of outgoing email to a user" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail/content> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail/content> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail/content> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail/content> rdfs:comment "The content of the email sent to the user." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail/comment> rdfs:comment "Additional comment about the outgoing comm." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail/subjectLine> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail/subjectLine> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail/subjectLine> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventEmail/subjectLine> rdfs:comment "The subject line of the email sent to the user." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag> rdfs:comment "Add/Remove a tag on a subject" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag/comment> rdfs:comment "Additional comment about added/removed tags." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag/add> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag/add> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag/add> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag/add> rdfs:comment "Tags to be added to the subject. If already exists, won't be duplicated." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag/remove> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag/remove> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag/remove> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTag/remove> rdfs:comment "Tags to be removed to the subject. Ignores a tag If it doesn't exist, won't be duplicated." .
+<https://atproto.social/ontology/app.bsky.actor.getProfile#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.getProfile#Main> rdfs:comment "Get detailed profile view of an actor. Does not require auth, but contains relevant metadata with auth." .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#FollowingRule> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#FollowingRule> rdfs:comment "FeedThreadgate_FollowingRule is a "followingRule" in the app.bsky.feed.threadgate schema.
+
+Allow replies from actors you follow.
+
+RECORDTYPE: FeedThreadgate_FollowingRule" .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonAppeal> a owl:Class .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonAppeal> rdfs:comment "Appeal: appeal a previously taken moderation action" .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValue> a owl:Class .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonType> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.createInviteCodes#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.createInviteCodes#Main> rdfs:comment "Create invite codes." .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Contact> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Contact/email> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Contact/email> rdfs:domain <https://atproto.social/ontology/com.atproto.server.describeServer#Contact> .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Contact/email> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.identity.updateHandle#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.identity.updateHandle#Main> rdfs:comment "Updates the current account's handle. Verifies handle validity, and updates did:plc document if necessary. Implemented by PDS, and requires auth." .
+<https://atproto.social/ontology/com.atproto.repo.uploadBlob#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.uploadBlob#Main> rdfs:comment "Upload a new blob, to be referenced from a repository record. The blob will be deleted if it is not referenced within a time window (eg, minutes). Blob restrictions (mimetype, size, etc) are enforced when the reference is created. Requires auth, implemented by PDS." .
+<https://atproto.social/ontology/com.atproto.sync.notifyOfUpdate#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.notifyOfUpdate#Main> rdfs:comment "Notify a crawling service of a recent update, and that crawling should resume. Intended use is after a gap between repo stream events caused the crawling service to disconnect. Does not require auth; implemented by Relay. DEPRECATED: just use com.atproto.sync.requestCrawl" .
+<https://atproto.social/ontology/app.bsky.graph.defs#Modlist> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.defs#Modlist> rdfs:comment "A list of actors to apply an aggregate moderation action (mute/block) on." .
+<https://atproto.social/ontology/app.bsky.unspecced.searchStarterPacksSkeleton#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.searchStarterPacksSkeleton#Main> rdfs:comment "Backend Starter Pack search, returns only skeleton." .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogMuteConvo> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogMuteConvo/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogMuteConvo/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogMuteConvo> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogMuteConvo/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogMuteConvo/convoId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogMuteConvo/convoId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogMuteConvo> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogMuteConvo/convoId> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.identity.resolveHandle#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.identity.resolveHandle#Main> rdfs:comment "Resolves an atproto handle (hostname) to a DID. Does not necessarily bi-directionally verify against the the DID document." .
+<https://atproto.social/ontology/app.bsky.graph.getRelationships#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getRelationships#Main> rdfs:comment "Enumerates public relationships between one account, and a list of other accounts. Does not require auth." .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem> rdfs:comment "UnspeccedGetPostThreadV2_ThreadItem is a "threadItem" in the app.bsky.unspecced.getPostThreadV2 schema." .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem/value> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem> .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem/value> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem> .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem/depth> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem/depth> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem> .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem/depth> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#ThreadItem/depth> rdfs:comment "depth: The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReverseTakedown> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReverseTakedown> rdfs:comment "Revert take down action on a subject" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReverseTakedown/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReverseTakedown/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReverseTakedown> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReverseTakedown/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReverseTakedown/comment> rdfs:comment "Describe reasoning behind the reversal." .
+<https://atproto.social/ontology/app.bsky.actor.putPreferences#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.putPreferences#Main> rdfs:comment "Set the private preferences attached to the account." .
+<https://atproto.social/ontology/app.bsky.actor.searchActors#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.searchActors#Main> rdfs:comment "Find actors (profiles) matching search criteria. Does not require auth." .
+<https://atproto.social/ontology/app.bsky.embed.defs#AspectRatio> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.defs#AspectRatio> rdfs:comment "EmbedDefs_AspectRatio is a "aspectRatio" in the app.bsky.embed.defs schema.
+
+width:height represents an aspect ratio. It may be approximate, and may not correspond to absolute dimensions in any given unit." .
+<https://atproto.social/ontology/app.bsky.embed.defs#AspectRatio/width> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.defs#AspectRatio/width> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.defs#AspectRatio> .
+<https://atproto.social/ontology/app.bsky.embed.defs#AspectRatio/width> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.embed.defs#AspectRatio/height> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.defs#AspectRatio/height> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.defs#AspectRatio> .
+<https://atproto.social/ontology/app.bsky.embed.defs#AspectRatio/height> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.getQuotes#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getQuotes#Main> rdfs:comment "Get a list of quotes for a given post." .
+<https://atproto.social/ontology/com.atproto.sync.requestCrawl#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.requestCrawl#Main> rdfs:comment "Request a service to persistently crawl hosted repos. Expected use is new PDS instances declaring their existence to Relays. Does not require auth." .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost> rdfs:comment "FeedDefs_ReasonRepost is a "reasonRepost" in the app.bsky.feed.defs schema.
+
+RECORDTYPE: FeedDefs_ReasonRepost" .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost/by> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost/by> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost/by> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#App.bsky.actor.defs#profileViewBasic> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonRepost/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#ClickthroughAuthor> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ClickthroughAuthor> rdfs:comment "User clicked through to the author of the feed item" .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic> rdfs:comment "UnspeccedDefs_TrendingTopic is a "trendingTopic" in the app.bsky.unspecced.defs schema." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic/displayName> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic/displayName> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic/displayName> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic/description> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic/description> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic/description> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic/link> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic/link> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic/link> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic/topic> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic/topic> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#TrendingTopic/topic> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.requestAccountDelete#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.requestAccountDelete#Main> rdfs:comment "Initiate a user account deletion via email." .
+<https://atproto.social/ontology/app.bsky.feed.post#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.post#Main> rdfs:comment "Record containing a Bluesky post." .
+<https://atproto.social/ontology/app.bsky.graph.verification#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.verification#Main> rdfs:comment "Record declaring a verification relationship between two accounts. Verifications are only considered valid by an app if issued by an account the app considers trusted." .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonViolation> a owl:Class .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonViolation> rdfs:comment "Direct violation of server rules, laws, terms of service" .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/invitesDisabled> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/invitesDisabled> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#AccountView> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/invitesDisabled> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/emailConfirmedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/emailConfirmedAt> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#AccountView> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/emailConfirmedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/inviteNote> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/inviteNote> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#AccountView> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/inviteNote> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/deactivatedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/deactivatedAt> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#AccountView> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/deactivatedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/invitedBy> a owl:ObjectProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/invitedBy> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#AccountView> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/invitedBy> rdfs:range <https://atproto.social/ontology/com.atproto.admin.defs#Com.atproto.server.defs#inviteCode> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/invites> a owl:ObjectProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/invites> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#AccountView> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/invites> rdfs:range <https://atproto.social/ontology/com.atproto.admin.defs#Com.atproto.server.defs#inviteCode> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/threatSignatures> a owl:ObjectProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/threatSignatures> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#AccountView> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/threatSignatures> rdfs:range <https://atproto.social/ontology/com.atproto.admin.defs#ThreatSignature> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/did> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#AccountView> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/handle> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#AccountView> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/email> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/email> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#AccountView> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/email> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/relatedRecords> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/relatedRecords> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#AccountView> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/relatedRecords> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/indexedAt> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#AccountView> .
+<https://atproto.social/ontology/com.atproto.admin.defs#AccountView/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.images#Image> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.images#Image> rdfs:comment "EmbedImages_Image is a "image" in the app.bsky.embed.images schema." .
+<https://atproto.social/ontology/app.bsky.embed.images#Image/image> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.images#Image/image> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.images#Image> .
+<https://atproto.social/ontology/app.bsky.embed.images#Image/image> rdfs:range xsd:base64Binary .
+<https://atproto.social/ontology/app.bsky.embed.images#Image/alt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.images#Image/alt> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.images#Image> .
+<https://atproto.social/ontology/app.bsky.embed.images#Image/alt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.images#Image/alt> rdfs:comment "alt: Alt text description of the image, for accessibility." .
+<https://atproto.social/ontology/app.bsky.embed.images#Image/aspectRatio> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.images#Image/aspectRatio> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.images#Image> .
+<https://atproto.social/ontology/app.bsky.embed.images#Image/aspectRatio> rdfs:range <https://atproto.social/ontology/app.bsky.embed.images#App.bsky.embed.defs#aspectRatio> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView> rdfs:comment "FeedDefs_PostView is a "postView" in the app.bsky.feed.defs schema.
+
+RECORDTYPE: FeedDefs_PostView" .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/likeCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/likeCount> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/likeCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/author> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/author> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/author> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#App.bsky.actor.defs#profileViewBasic> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/repostCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/repostCount> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/repostCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/quoteCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/quoteCount> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/quoteCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/viewer> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/viewer> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/viewer> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/labels> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/threadgate> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/threadgate> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/threadgate> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#ThreadgateView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/record> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/record> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/record> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/embed> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/embed> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/embed> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/replyCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/replyCount> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#PostView/replyCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.unspecced.getPopularFeedGenerators#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getPopularFeedGenerators#Main> rdfs:comment "An unspecced view of globally popular feed generators." .
+<https://atproto.social/ontology/chat.bsky.convo.updateAllRead#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.getEvent#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.getEvent#Main> rdfs:comment "Get details about a moderation event." .
+<https://atproto.social/ontology/app.bsky.actor.getProfiles#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.getProfiles#Main> rdfs:comment "Get detailed profile views of multiple actors." .
+<https://atproto.social/ontology/app.bsky.graph.muteThread#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.muteThread#Main> rdfs:comment "Mutes a thread preventing notifications from the thread and any of its children. Mutes are private in Bluesky. Requires auth." .
+<https://atproto.social/ontology/app.bsky.notification.getPreferences#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.getPreferences#Main> rdfs:comment "Get notification-related preferences for an account. Requires auth." .
+<https://atproto.social/ontology/chat.bsky.moderation.getMessageContext#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.labeler.service#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.labeler.service#Main> rdfs:comment "A declaration of the existence of labeler service." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemNoUnauthenticated> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemNoUnauthenticated> rdfs:comment "UnspeccedDefs_ThreadItemNoUnauthenticated is a "threadItemNoUnauthenticated" in the app.bsky.unspecced.defs schema.
+
+RECORDTYPE: UnspeccedDefs_ThreadItemNoUnauthenticated" .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadV2#Main> rdfs:comment "(NOTE: this endpoint is under development and WILL change without notice. Don't use it until it is moved out of `unspecced` or your application WILL break) Get posts in a thread. It is based in an anchor post at any depth of the tree, and returns posts above it (recursively resolving the parent, without further branching to their replies) and below it (recursive replies, with branching to their replies). Does not require auth, but additional metadata and filtering will be applied for authed requests." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReviewEscalated> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReviewEscalated> rdfs:comment "Moderator review status of a subject: Escalated. Indicates that the subject was escalated for review by a moderator" .
+<https://atproto.social/ontology/com.atproto.sync.defs#HostStatus> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.set.deleteValues#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.set.deleteValues#Main> rdfs:comment "Delete values from a specific set. Attempting to delete values that are not in the set will not result in an error" .
+<https://atproto.social/ontology/app.bsky.feed.getFeedGenerator#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getFeedGenerator#Main> rdfs:comment "Get information about a feed generator. Implemented by AppView." .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#ListRule> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#ListRule> rdfs:comment "FeedThreadgate_ListRule is a "listRule" in the app.bsky.feed.threadgate schema.
+
+Allow replies from actors on a list.
+
+RECORDTYPE: FeedThreadgate_ListRule" .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#ListRule/list> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#ListRule/list> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.threadgate#ListRule> .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#ListRule/list> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.getSuggestedFollowsByActor#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getSuggestedFollowsByActor#Main> rdfs:comment "Enumerates follows similar to a given account (actor). Expected use is to recommend additional accounts immediately after following one account." .
+<https://atproto.social/ontology/app.bsky.graph.unmuteThread#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.unmuteThread#Main> rdfs:comment "Unmutes the specified thread. Requires auth." .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewDetached> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewDetached> rdfs:comment "EmbedRecord_ViewDetached is a "viewDetached" in the app.bsky.embed.record schema.
+
+RECORDTYPE: EmbedRecord_ViewDetached" .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewDetached/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewDetached/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewDetached> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewDetached/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewDetached/detached> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewDetached/detached> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewDetached> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewDetached/detached> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.graph.listitem#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.listitem#Main> rdfs:comment "Record representing an account's inclusion on a specific list. The AppView will ignore duplicate listitem records." .
+<https://atproto.social/ontology/tools.ozone.team.updateMember#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.team.updateMember#Main> rdfs:comment "Update a member in the ozone service. Requires admin role." .
+<https://atproto.social/ontology/app.bsky.feed.like#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.like#Main> rdfs:comment "Record declaring a 'like' of a piece of subject content." .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageViewSender> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageViewSender/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageViewSender/did> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageViewSender> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageViewSender/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats> rdfs:comment "Statistics about a set of record subject items" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/takendownCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/takendownCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/takendownCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/takendownCount> rdfs:comment "Number of item currently taken down" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/totalReports> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/totalReports> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/totalReports> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/totalReports> rdfs:comment "Cumulative sum of the number of reports on the items in the set" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/reportedCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/reportedCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/reportedCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/reportedCount> rdfs:comment "Number of items that were reported at least once" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/escalatedCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/escalatedCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/escalatedCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/escalatedCount> rdfs:comment "Number of items that were escalated at least once" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/appealedCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/appealedCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/appealedCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/appealedCount> rdfs:comment "Number of items that were appealed at least once" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/subjectCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/subjectCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/subjectCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/subjectCount> rdfs:comment "Total number of item in the set" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/pendingCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/pendingCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/pendingCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/pendingCount> rdfs:comment "Number of item currently in "reviewOpen" or "reviewEscalated" state" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/processedCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/processedCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/processedCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordsStats/processedCount> rdfs:comment "Number of item currently in "reviewNone" or "reviewClosed" state" .
+<https://atproto.social/ontology/tools.ozone.setting.listOptions#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.setting.listOptions#Main> rdfs:comment "List settings with optional filtering" .
+<https://atproto.social/ontology/app.bsky.feed.defs#ClickthroughItem> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ClickthroughItem> rdfs:comment "User clicked through to the feed item" .
+<https://atproto.social/ontology/com.atproto.repo.putRecord#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.putRecord#Main> rdfs:comment "Write a repository record, creating or updating it as needed. Requires auth, implemented by PDS." .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonPin> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReasonPin> rdfs:comment "FeedDefs_ReasonPin is a "reasonPin" in the app.bsky.feed.defs schema.
+
+RECORDTYPE: FeedDefs_ReasonPin" .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewerState> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewerState> rdfs:comment "GraphDefs_ListViewerState is a "listViewerState" in the app.bsky.graph.defs schema." .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewerState/muted> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewerState/muted> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListViewerState> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewerState/muted> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewerState/blocked> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewerState/blocked> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListViewerState> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListViewerState/blocked> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerPolicies> a owl:Class .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerPolicies> rdfs:comment "LabelerDefs_LabelerPolicies is a "labelerPolicies" in the app.bsky.labeler.defs schema." .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerPolicies/labelValues> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerPolicies/labelValues> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerPolicies> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerPolicies/labelValues> rdfs:range <https://atproto.social/ontology/app.bsky.labeler.defs#Com.atproto.label.defs#labelValue> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerPolicies/labelValues> rdfs:comment "labelValues: The label values which this labeler publishes. May include global or custom labels." .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerPolicies/labelValueDefinitions> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerPolicies/labelValueDefinitions> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerPolicies> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerPolicies/labelValueDefinitions> rdfs:range <https://atproto.social/ontology/app.bsky.labeler.defs#Com.atproto.label.defs#labelValueDefinition> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerPolicies/labelValueDefinitions> rdfs:comment "labelValueDefinitions: Label values created by this labeler and scoped exclusively to it. Labels defined here will override global label definitions for this labeler." .
+<https://atproto.social/ontology/tools.ozone.signature.findCorrelation#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.signature.findCorrelation#Main> rdfs:comment "Find all correlated threat signatures between 2 or more accounts." .
+<https://atproto.social/ontology/tools.ozone.moderation.getRecords#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.getRecords#Main> rdfs:comment "Get details about some records." .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/updatedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/updatedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.set.defs#SetView> .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/updatedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/name> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/name> rdfs:domain <https://atproto.social/ontology/tools.ozone.set.defs#SetView> .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/name> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/description> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/description> rdfs:domain <https://atproto.social/ontology/tools.ozone.set.defs#SetView> .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/description> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/setSize> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/setSize> rdfs:domain <https://atproto.social/ontology/tools.ozone.set.defs#SetView> .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/setSize> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.set.defs#SetView> .
+<https://atproto.social/ontology/tools.ozone.set.defs#SetView/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/did> rdfs:domain <https://atproto.social/ontology/tools.ozone.team.defs#Member> .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/disabled> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/disabled> rdfs:domain <https://atproto.social/ontology/tools.ozone.team.defs#Member> .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/disabled> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/profile> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/profile> rdfs:domain <https://atproto.social/ontology/tools.ozone.team.defs#Member> .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/profile> rdfs:range <https://atproto.social/ontology/tools.ozone.team.defs#App.bsky.actor.defs#profileViewDetailed> .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.team.defs#Member> .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/updatedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/updatedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.team.defs#Member> .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/updatedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/lastUpdatedBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/lastUpdatedBy> rdfs:domain <https://atproto.social/ontology/tools.ozone.team.defs#Member> .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/lastUpdatedBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/role> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/role> rdfs:domain <https://atproto.social/ontology/tools.ozone.team.defs#Member> .
+<https://atproto.social/ontology/tools.ozone.team.defs#Member/role> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#InteractionQuote> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#InteractionQuote> rdfs:comment "User quoted the feed item" .
+<https://atproto.social/ontology/app.bsky.notification.putPreferencesV2#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.putPreferencesV2#Main> rdfs:comment "Set notification-related preferences for an account. Requires auth." .
+<https://atproto.social/ontology/com.atproto.admin.deleteAccount#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.deleteAccount#Main> rdfs:comment "Delete a user account as an administrator." .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings> a owl:Class .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings> rdfs:comment "Strings which describe the label in the UI, localized into a specific language." .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings/name> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings/name> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings> .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings/name> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings/name> rdfs:comment "A short human-readable name for the label." .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings/description> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings/description> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings> .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings/description> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings/description> rdfs:comment "A longer description of what the label means and why it might be applied." .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings/lang> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings/lang> rdfs:domain <https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings> .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings/lang> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.defs#LabelValueDefinitionStrings/lang> rdfs:comment "The code of the language these strings are written in." .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Feed> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Feed> rdfs:comment "FeedDescribeFeedGenerator_Feed is a "feed" in the app.bsky.feed.describeFeedGenerator schema." .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Feed/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Feed/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Feed> .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Feed/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.searchRepos#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.searchRepos#Main> rdfs:comment "Find repositories based on a search term." .
+<https://atproto.social/ontology/tools.ozone.set.upsertSet#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.set.upsertSet#Main> rdfs:comment "Create or update set metadata" .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref> rdfs:comment "ActorDefs_BskyAppStatePref is a "bskyAppStatePref" in the app.bsky.actor.defs schema.
+
+A grab bag of state that's specific to the bsky.app program. Third-party apps shouldn't use this.
+
+RECORDTYPE: ActorDefs_BskyAppStatePref" .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref/activeProgressGuide> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref/activeProgressGuide> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref/activeProgressGuide> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#BskyAppProgressGuide> .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref/queuedNudges> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref/queuedNudges> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref/queuedNudges> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref/queuedNudges> rdfs:comment "queuedNudges: An array of tokens which identify nudges (modals, popups, tours, highlight dots) that should be shown to the user." .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref/nuxs> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref/nuxs> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref/nuxs> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#App.bsky.actor.defs#nux> .
+<https://atproto.social/ontology/app.bsky.actor.defs#BskyAppStatePref/nuxs> rdfs:comment "nuxs: Storage for NUXs the user has encountered." .
+<https://atproto.social/ontology/tools.ozone.communication.deleteTemplate#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.communication.deleteTemplate#Main> rdfs:comment "Delete a communication template." .
+<https://atproto.social/ontology/app.bsky.unspecced.getTrendingTopics#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getTrendingTopics#Main> rdfs:comment "Get a list of trending topics" .
+<https://atproto.social/ontology/com.atproto.server.createSession#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.createSession#Main> rdfs:comment "Create an authentication session." .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord> rdfs:comment "ActorDefs_MutedWord is a "mutedWord" in the app.bsky.actor.defs schema.
+
+A word that the account owner has muted." .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/id> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/id> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#MutedWord> .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/id> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/value> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#MutedWord> .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/value> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/value> rdfs:comment "value: The muted word itself." .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/targets> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/targets> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#MutedWord> .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/targets> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#App.bsky.actor.defs#mutedWordTarget> .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/targets> rdfs:comment "targets: The intended targets of the muted word." .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/actorTarget> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/actorTarget> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#MutedWord> .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/actorTarget> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/actorTarget> rdfs:comment "actorTarget: Groups of users to apply the muted word to. If undefined, applies to all users." .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/expiresAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/expiresAt> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#MutedWord> .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/expiresAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWord/expiresAt> rdfs:comment "expiresAt: The date and time at which the muted word will expire and no longer be applied." .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction> rdfs:comment "FeedDefs_Interaction is a "interaction" in the app.bsky.feed.defs schema." .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/item> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/item> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#Interaction> .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/item> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/event> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/event> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#Interaction> .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/event> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/feedContext> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/feedContext> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#Interaction> .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/feedContext> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/feedContext> rdfs:comment "feedContext: Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton." .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/reqId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/reqId> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#Interaction> .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/reqId> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#Interaction/reqId> rdfs:comment "reqId: Unique identifier per request that may be passed back alongside interactions." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchActor> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchActor> rdfs:comment "UnspeccedDefs_SkeletonSearchActor is a "skeletonSearchActor" in the app.bsky.unspecced.defs schema." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchActor/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchActor/did> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchActor> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchActor/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.richtext.facet#ByteSlice> a owl:Class .
+<https://atproto.social/ontology/app.bsky.richtext.facet#ByteSlice> rdfs:comment "RichtextFacet_ByteSlice is a "byteSlice" in the app.bsky.richtext.facet schema.
+
+Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets." .
+<https://atproto.social/ontology/app.bsky.richtext.facet#ByteSlice/byteStart> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.richtext.facet#ByteSlice/byteStart> rdfs:domain <https://atproto.social/ontology/app.bsky.richtext.facet#ByteSlice> .
+<https://atproto.social/ontology/app.bsky.richtext.facet#ByteSlice/byteStart> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.richtext.facet#ByteSlice/byteEnd> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.richtext.facet#ByteSlice/byteEnd> rdfs:domain <https://atproto.social/ontology/app.bsky.richtext.facet#ByteSlice> .
+<https://atproto.social/ontology/app.bsky.richtext.facet#ByteSlice/byteEnd> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonOther> a owl:Class .
+<https://atproto.social/ontology/com.atproto.moderation.defs#ReasonOther> rdfs:comment "Other: reports not falling under another report category" .
+<https://atproto.social/ontology/tools.ozone.server.getConfig#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.server.getConfig#Main> rdfs:comment "Get details about ozone's server configuration." .
+<https://atproto.social/ontology/app.bsky.actor.status#Live> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.status#Live> rdfs:comment "Advertises an account as currently offering live content." .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage> rdfs:comment "EmbedImages_ViewImage is a "viewImage" in the app.bsky.embed.images schema." .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/thumb> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/thumb> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.images#ViewImage> .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/thumb> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/thumb> rdfs:comment "thumb: Fully-qualified URL where a thumbnail of the image can be fetched. For example, CDN location provided by the App View." .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/fullsize> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/fullsize> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.images#ViewImage> .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/fullsize> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/fullsize> rdfs:comment "fullsize: Fully-qualified URL where a large version of the image can be fetched. May or may not be the exact original blob. For example, CDN location provided by the App View." .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/alt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/alt> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.images#ViewImage> .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/alt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/alt> rdfs:comment "alt: Alt text description of the image, for accessibility." .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/aspectRatio> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/aspectRatio> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.images#ViewImage> .
+<https://atproto.social/ontology/app.bsky.embed.images#ViewImage/aspectRatio> rdfs:range <https://atproto.social/ontology/app.bsky.embed.images#App.bsky.embed.defs#aspectRatio> .
+<https://atproto.social/ontology/app.bsky.graph.starterpack#FeedItem> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.starterpack#FeedItem> rdfs:comment "GraphStarterpack_FeedItem is a "feedItem" in the app.bsky.graph.starterpack schema." .
+<https://atproto.social/ontology/app.bsky.graph.starterpack#FeedItem/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.starterpack#FeedItem/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.starterpack#FeedItem> .
+<https://atproto.social/ontology/app.bsky.graph.starterpack#FeedItem/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Main> rdfs:comment "Enumerate notifications for the requesting account. Requires auth." .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView/sender> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView/sender> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView/sender> rdfs:range <https://atproto.social/ontology/chat.bsky.convo.defs#MessageViewSender> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView/sentAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView/sentAt> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView/sentAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView/id> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView/id> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#DeletedMessageView/id> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.identity.signPlcOperation#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.identity.signPlcOperation#Main> rdfs:comment "Signs a PLC operation to update some value(s) in the requesting DID's document." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport> rdfs:comment "Report a subject" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport/isReporterMuted> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport/isReporterMuted> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport/isReporterMuted> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport/isReporterMuted> rdfs:comment "Set to true if the reporter was muted from reporting at the time of the event. These reports won't impact the reviewState of the subject." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport/reportType> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport/reportType> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventReport/reportType> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#Com.atproto.moderation.defs#reasonType> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown> rdfs:comment "Take down a subject permanently or temporarily" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/durationInHours> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/durationInHours> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/durationInHours> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/durationInHours> rdfs:comment "Indicates how long the takedown should be in effect before automatically expiring." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/acknowledgeAccountSubjects> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/acknowledgeAccountSubjects> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/acknowledgeAccountSubjects> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/acknowledgeAccountSubjects> rdfs:comment "If true, all other reports on content authored by this account will be resolved (acknowledged)." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/policies> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/policies> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/policies> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventTakedown/policies> rdfs:comment "Names/Keywords of the policies that drove the decision." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/indexedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/invitedBy> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/invitedBy> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/invitedBy> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#Com.atproto.server.defs#inviteCode> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/deactivatedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/deactivatedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/deactivatedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/threatSignatures> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/threatSignatures> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/threatSignatures> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#Com.atproto.admin.defs#threatSignature> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/did> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/relatedRecords> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/relatedRecords> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/relatedRecords> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/moderation> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/moderation> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/moderation> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#Moderation> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/invitesDisabled> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/invitesDisabled> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/invitesDisabled> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/inviteNote> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/inviteNote> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/inviteNote> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/handle> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/email> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/email> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView/email> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.post#Entity> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.post#Entity> rdfs:comment "FeedPost_Entity is a "entity" in the app.bsky.feed.post schema.
+
+Deprecated: use facets instead." .
+<https://atproto.social/ontology/app.bsky.feed.post#Entity/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.post#Entity/value> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.post#Entity> .
+<https://atproto.social/ontology/app.bsky.feed.post#Entity/value> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.post#Entity/index> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.post#Entity/index> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.post#Entity> .
+<https://atproto.social/ontology/app.bsky.feed.post#Entity/index> rdfs:range <https://atproto.social/ontology/app.bsky.feed.post#TextSlice> .
+<https://atproto.social/ontology/app.bsky.feed.post#Entity/type> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.post#Entity/type> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.post#Entity> .
+<https://atproto.social/ontology/app.bsky.feed.post#Entity/type> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.post#Entity/type> rdfs:comment "type: Expected values are 'mention' and 'link'." .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification> rdfs:comment "NotificationListNotifications_Notification is a "notification" in the app.bsky.notification.listNotifications schema." .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/reasonSubject> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/reasonSubject> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification> .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/reasonSubject> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/record> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/record> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification> .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/record> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/isRead> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/isRead> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification> .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/isRead> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/author> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/author> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification> .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/author> rdfs:range <https://atproto.social/ontology/app.bsky.notification.listNotifications#App.bsky.actor.defs#profileView> .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification> .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/reason> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/reason> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification> .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/reason> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/reason> rdfs:comment "reason: The reason why this notification was delivered - e.g. your post was liked, or you received a new follower." .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification> .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification> .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/labels> rdfs:range <https://atproto.social/ontology/app.bsky.notification.listNotifications#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification> .
+<https://atproto.social/ontology/app.bsky.notification.listNotifications#Notification/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.getLatestCommit#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.getLatestCommit#Main> rdfs:comment "Get the current commit CID & revision of the specified repo. Does not require auth." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmute> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmute> rdfs:comment "Unmute action on a subject" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmute/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmute/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmute> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmute/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventUnmute/comment> rdfs:comment "Describe reasoning behind the reversal." .
+<https://atproto.social/ontology/app.bsky.feed.defs#InteractionSeen> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#InteractionSeen> rdfs:comment "Feed item was seen by user" .
+<https://atproto.social/ontology/com.atproto.admin.defs#StatusAttr> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.defs#StatusAttr/applied> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#StatusAttr/applied> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#StatusAttr> .
+<https://atproto.social/ontology/com.atproto.admin.defs#StatusAttr/applied> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/com.atproto.admin.defs#StatusAttr/ref> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#StatusAttr/ref> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#StatusAttr> .
+<https://atproto.social/ontology/com.atproto.admin.defs#StatusAttr/ref> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.admin.enableAccountInvites#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.enableAccountInvites#Main> rdfs:comment "Re-enable an account's ability to receive invite codes." .
+<https://atproto.social/ontology/com.atproto.repo.strongRef#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.strongRef#Main/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.strongRef#Main/uri> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.strongRef#Main> .
+<https://atproto.social/ontology/com.atproto.repo.strongRef#Main/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.strongRef#Main/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.strongRef#Main/cid> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.strongRef#Main> .
+<https://atproto.social/ontology/com.atproto.repo.strongRef#Main/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.team.addMember#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.team.addMember#Main> rdfs:comment "Add a member to the ozone team. Requires admin role." .
+<https://atproto.social/ontology/app.bsky.feed.defs#ClickthroughReposter> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ClickthroughReposter> rdfs:comment "User clicked through to the reposter of the feed item" .
+<https://atproto.social/ontology/app.bsky.graph.getFollowers#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getFollowers#Main> rdfs:comment "Enumerates accounts which follow a specified account (actor)." .
+<https://atproto.social/ontology/com.atproto.server.createAccount#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.createAccount#Main> rdfs:comment "Create an account. Implemented by PDS." .
+<https://atproto.social/ontology/com.atproto.server.reserveSigningKey#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.reserveSigningKey#Main> rdfs:comment "Reserve a repo signing key, for use with account creation. Necessary so that a DID PLC update operation can be constructed during an account migraiton. Public and does not require auth; implemented by PDS. NOTE: this endpoint may change when full account migration is implemented." .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewerState> a owl:Class .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewerState> rdfs:comment "LabelerDefs_LabelerViewerState is a "labelerViewerState" in the app.bsky.labeler.defs schema." .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewerState/like> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewerState/like> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewerState> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewerState/like> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestedStarterPacksSkeleton#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestedStarterPacksSkeleton#Main> rdfs:comment "Get a skeleton of suggested starterpacks. Intended to be called and hydrated by app.bsky.unspecced.getSuggestedStarterpacks" .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus> a owl:Class .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus> rdfs:comment "VideoDefs_JobStatus is a "jobStatus" in the app.bsky.video.defs schema." .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/error> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/error> rdfs:domain <https://atproto.social/ontology/app.bsky.video.defs#JobStatus> .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/error> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/message> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/message> rdfs:domain <https://atproto.social/ontology/app.bsky.video.defs#JobStatus> .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/message> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/jobId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/jobId> rdfs:domain <https://atproto.social/ontology/app.bsky.video.defs#JobStatus> .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/jobId> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/did> rdfs:domain <https://atproto.social/ontology/app.bsky.video.defs#JobStatus> .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/state> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/state> rdfs:domain <https://atproto.social/ontology/app.bsky.video.defs#JobStatus> .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/state> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/state> rdfs:comment "state: The state of the video processing job. All values not listed as a known value indicate that the job is in process." .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/progress> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/progress> rdfs:domain <https://atproto.social/ontology/app.bsky.video.defs#JobStatus> .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/progress> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/progress> rdfs:comment "progress: Progress within the current processing state." .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/blob> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/blob> rdfs:domain <https://atproto.social/ontology/app.bsky.video.defs#JobStatus> .
+<https://atproto.social/ontology/app.bsky.video.defs#JobStatus/blob> rdfs:range xsd:base64Binary .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventComment> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventComment> rdfs:comment "Add a comment to a subject. An empty comment will clear any previously set sticky comment." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventComment/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventComment/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventComment> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventComment/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventComment/sticky> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventComment/sticky> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventComment> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventComment/sticky> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventComment/sticky> rdfs:comment "Make the comment persistent on the subject" .
+<https://atproto.social/ontology/tools.ozone.moderation.emitEvent#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.emitEvent#Main> rdfs:comment "Take a moderation action on an actor." .
+<https://atproto.social/ontology/chat.bsky.convo.acceptConvo#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/subject> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/subject> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/subject> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/subjectBlobs> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/subjectBlobs> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/subjectBlobs> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#BlobView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/createdBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/createdBy> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/createdBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/id> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/id> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/id> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/event> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/event> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventViewDetail/event> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked> rdfs:comment "EmbedRecord_ViewBlocked is a "viewBlocked" in the app.bsky.embed.record schema.
+
+RECORDTYPE: EmbedRecord_ViewBlocked" .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked/blocked> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked/blocked> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked/blocked> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked/author> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked/author> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewBlocked/author> rdfs:range <https://atproto.social/ontology/app.bsky.embed.record#App.bsky.feed.defs#blockedAuthor> .
+<https://atproto.social/ontology/app.bsky.feed.post#TextSlice> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.post#TextSlice> rdfs:comment "FeedPost_TextSlice is a "textSlice" in the app.bsky.feed.post schema.
+
+Deprecated. Use app.bsky.richtext instead -- A text segment. Start is inclusive, end is exclusive. Indices are for utf16-encoded strings." .
+<https://atproto.social/ontology/app.bsky.feed.post#TextSlice/start> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.post#TextSlice/start> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.post#TextSlice> .
+<https://atproto.social/ontology/app.bsky.feed.post#TextSlice/start> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.post#TextSlice/end> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.post#TextSlice/end> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.post#TextSlice> .
+<https://atproto.social/ontology/app.bsky.feed.post#TextSlice/end> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.graph.defs#Referencelist> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.defs#Referencelist> rdfs:comment "A list of actors used for only for reference purposes such as within a starter pack." .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView> a owl:Class .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView> rdfs:comment "LabelerDefs_LabelerView is a "labelerView" in the app.bsky.labeler.defs schema.
+
+RECORDTYPE: LabelerDefs_LabelerView" .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/creator> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/creator> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/creator> rdfs:range <https://atproto.social/ontology/app.bsky.labeler.defs#App.bsky.actor.defs#profileView> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/likeCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/likeCount> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/likeCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/viewer> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/viewer> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/viewer> rdfs:range <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewerState> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerView/labels> rdfs:range <https://atproto.social/ontology/app.bsky.labeler.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Main> rdfs:comment "Enumerates all the DID, rev, and commit CID for all repos hosted by this service. Does not require auth; implemented by PDS and Relay." .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/subject> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/subject> rdfs:domain <https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView> .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/subject> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/subject> rdfs:comment "Content of the template, can contain markdown and variable placeholders." .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/disabled> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/disabled> rdfs:domain <https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView> .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/disabled> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/lang> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/lang> rdfs:domain <https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView> .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/lang> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/lang> rdfs:comment "Message language." .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView> .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/updatedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/updatedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView> .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/updatedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/name> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/name> rdfs:domain <https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView> .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/name> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/name> rdfs:comment "Name of the template." .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/contentMarkdown> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/contentMarkdown> rdfs:domain <https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView> .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/contentMarkdown> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/contentMarkdown> rdfs:comment "Subject of the message, used in emails." .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/lastUpdatedBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/lastUpdatedBy> rdfs:domain <https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView> .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/lastUpdatedBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/lastUpdatedBy> rdfs:comment "DID of the user who last updated the template." .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/id> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/id> rdfs:domain <https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView> .
+<https://atproto.social/ontology/tools.ozone.communication.defs#TemplateView/id> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account> rdfs:comment "Represents a change to an account's status on a host (eg, PDS or Relay). The semantics of this event are that the status is at the host which emitted the event, not necessarily that at the currently active PDS. Eg, a Relay takedown would emit a takedown with active=false, even if the PDS is still active." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/seq> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/seq> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/seq> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/did> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/time> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/time> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/time> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/active> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/active> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/active> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/active> rdfs:comment "Indicates that the account has a repository which can be fetched from the host that emitted this event." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/status> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/status> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/status> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Account/status> rdfs:comment "If active=false, this optional field indicates a reason for why the account is not active." .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Links> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Links> rdfs:comment "FeedDescribeFeedGenerator_Links is a "links" in the app.bsky.feed.describeFeedGenerator schema." .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Links/privacyPolicy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Links/privacyPolicy> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Links> .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Links/privacyPolicy> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Links/termsOfService> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Links/termsOfService> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Links> .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Links/termsOfService> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#MentionRule> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#MentionRule> rdfs:comment "FeedThreadgate_MentionRule is a "mentionRule" in the app.bsky.feed.threadgate schema.
+
+Allow replies from actors mentioned in your post.
+
+RECORDTYPE: FeedThreadgate_MentionRule" .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Mention> a owl:Class .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Mention> rdfs:comment "RichtextFacet_Mention is a "mention" in the app.bsky.richtext.facet schema.
+
+Facet feature for mention of another account. The text is usually a handle, including a '@' prefix, but the facet reference is a DID.
+
+RECORDTYPE: RichtextFacet_Mention" .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Mention/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Mention/did> rdfs:domain <https://atproto.social/ontology/app.bsky.richtext.facet#Mention> .
+<https://atproto.social/ontology/app.bsky.richtext.facet#Mention/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.sendMessageBatch#BatchItem> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.sendMessageBatch#BatchItem/convoId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.sendMessageBatch#BatchItem/convoId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.sendMessageBatch#BatchItem> .
+<https://atproto.social/ontology/chat.bsky.convo.sendMessageBatch#BatchItem/convoId> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.sendMessageBatch#BatchItem/message> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.convo.sendMessageBatch#BatchItem/message> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.sendMessageBatch#BatchItem> .
+<https://atproto.social/ontology/chat.bsky.convo.sendMessageBatch#BatchItem/message> rdfs:range <https://atproto.social/ontology/chat.bsky.convo.sendMessageBatch#Chat.bsky.convo.defs#messageInput> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput/text> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput/text> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput/text> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput/facets> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput/facets> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput/facets> rdfs:range <https://atproto.social/ontology/chat.bsky.convo.defs#App.bsky.richtext.facet> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput/facets> rdfs:comment "Annotations of text (mentions, URLs, hashtags, etc)" .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput/embed> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput/embed> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageInput/embed> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.post#ReplyRef> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.post#ReplyRef> rdfs:comment "FeedPost_ReplyRef is a "replyRef" in the app.bsky.feed.post schema." .
+<https://atproto.social/ontology/app.bsky.feed.post#ReplyRef/parent> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.post#ReplyRef/parent> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.post#ReplyRef> .
+<https://atproto.social/ontology/app.bsky.feed.post#ReplyRef/parent> rdfs:range <https://atproto.social/ontology/app.bsky.feed.post#Com.atproto.repo.strongRef> .
+<https://atproto.social/ontology/app.bsky.feed.post#ReplyRef/root> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.post#ReplyRef/root> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.post#ReplyRef> .
+<https://atproto.social/ontology/app.bsky.feed.post#ReplyRef/root> rdfs:range <https://atproto.social/ontology/app.bsky.feed.post#Com.atproto.repo.strongRef> .
+<https://atproto.social/ontology/app.bsky.graph.starterpack#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.starterpack#Main> rdfs:comment "Record defining a starter pack of actors and feeds for new users." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent> rdfs:comment "Logs lifecycle event on a record subject. Normally captured by automod from the firehose and emitted to ozone for historical tracking." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent/op> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent/op> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent/op> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent/cid> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent/timestamp> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent/timestamp> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent/timestamp> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordEvent/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#HandleUpdated> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#HandleUpdated/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#HandleUpdated/handle> rdfs:domain <https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#HandleUpdated> .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#HandleUpdated/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/uri> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/cid> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/value> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/value> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/blobCids> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/blobCids> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/blobCids> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/indexedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/moderation> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/moderation> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/moderation> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#Moderation> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/repo> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/repo> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordView/repo> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoView> .
+<https://atproto.social/ontology/tools.ozone.team.defs#RoleVerifier> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.team.defs#RoleVerifier> rdfs:comment "Verifier role. Only allowed to issue verifications." .
+<https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#RevokeError> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#RevokeError> rdfs:comment "Error object for failed revocations" .
+<https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#RevokeError/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#RevokeError/uri> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#RevokeError> .
+<https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#RevokeError/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#RevokeError/uri> rdfs:comment "The AT-URI of the verification record that failed to revoke." .
+<https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#RevokeError/error> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#RevokeError/error> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#RevokeError> .
+<https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#RevokeError/error> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.revokeVerifications#RevokeError/error> rdfs:comment "Description of the error that occurred during revocation." .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedAuthor> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedAuthor> rdfs:comment "FeedDefs_BlockedAuthor is a "blockedAuthor" in the app.bsky.feed.defs schema." .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedAuthor/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedAuthor/did> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#BlockedAuthor> .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedAuthor/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedAuthor/viewer> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedAuthor/viewer> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#BlockedAuthor> .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedAuthor/viewer> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#App.bsky.actor.defs#viewerState> .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#EmailConfirmed> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#EmailConfirmed/email> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#EmailConfirmed/email> rdfs:domain <https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#EmailConfirmed> .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#EmailConfirmed/email> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.queryStatuses#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.queryStatuses#Main> rdfs:comment "View moderation statuses of subjects (record or repo)." .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> rdfs:comment "EmbedRecord_ViewRecord is a "viewRecord" in the app.bsky.embed.record schema.
+
+RECORDTYPE: EmbedRecord_ViewRecord" .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/value> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/value> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/value> rdfs:comment "value: The record data itself." .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/labels> rdfs:range <https://atproto.social/ontology/app.bsky.embed.record#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/repostCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/repostCount> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/repostCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/quoteCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/quoteCount> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/quoteCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/author> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/author> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/author> rdfs:range <https://atproto.social/ontology/app.bsky.embed.record#App.bsky.actor.defs#profileViewBasic> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/replyCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/replyCount> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/replyCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/likeCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/likeCount> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/likeCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/embeds> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/embeds> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/embeds> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewRecord> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewRecord/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.describeFeedGenerator#Main> rdfs:comment "Get information about a feed generator, including policies and offered feed URIs. Does not require auth; implemented by Feed Generator services (not App View)." .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#View> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#View> rdfs:comment "EmbedRecordWithMedia_View is a "view" in the app.bsky.embed.recordWithMedia schema.
+
+RECORDTYPE: EmbedRecordWithMedia_View" .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#View/record> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#View/record> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.recordWithMedia#View> .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#View/record> rdfs:range <https://atproto.social/ontology/app.bsky.embed.recordWithMedia#App.bsky.embed.record#view> .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#View/media> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#View/media> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.recordWithMedia#View> .
+<https://atproto.social/ontology/app.bsky.embed.recordWithMedia#View/media> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.admin.updateAccountSigningKey#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.updateAccountSigningKey#Main> rdfs:comment "Administrative action to update an account's signing key in their Did document." .
+<https://atproto.social/ontology/com.atproto.server.createInviteCode#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.createInviteCode#Main> rdfs:comment "Create an invite code." .
+<https://atproto.social/ontology/com.atproto.server.requestPasswordReset#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.requestPasswordReset#Main> rdfs:comment "Initiate a user account password reset via email." .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux> rdfs:comment "ActorDefs_Nux is a "nux" in the app.bsky.actor.defs schema.
+
+A new user experiences (NUX) storage object" .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/id> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/id> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#Nux> .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/id> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/completed> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/completed> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#Nux> .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/completed> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/data> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/data> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#Nux> .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/data> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/data> rdfs:comment "data: Arbitrary data for the NUX. The structure is defined by the NUX itself. Limited to 300 characters." .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/expiresAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/expiresAt> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#Nux> .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/expiresAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#Nux/expiresAt> rdfs:comment "expiresAt: The date and time at which the NUX will expire and should be considered completed." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventDivert> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventDivert> rdfs:comment "Divert a record's blobs to a 3rd party service for further scanning/tagging" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventDivert/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventDivert/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventDivert> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventDivert/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.signature.defs#SigDetail> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.signature.defs#SigDetail/property> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.signature.defs#SigDetail/property> rdfs:domain <https://atproto.social/ontology/tools.ozone.signature.defs#SigDetail> .
+<https://atproto.social/ontology/tools.ozone.signature.defs#SigDetail/property> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.signature.defs#SigDetail/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.signature.defs#SigDetail/value> rdfs:domain <https://atproto.social/ontology/tools.ozone.signature.defs#SigDetail> .
+<https://atproto.social/ontology/tools.ozone.signature.defs#SigDetail/value> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost> rdfs:comment "FeedDefs_FeedViewPost is a "feedViewPost" in the app.bsky.feed.defs schema." .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/post> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/post> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/post> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#PostView> .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/reply> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/reply> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/reply> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef> .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/reason> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/reason> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/reason> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/feedContext> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/feedContext> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/feedContext> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/feedContext> rdfs:comment "feedContext: Context provided by feed generator that may be passed back alongside interactions." .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/reqId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/reqId> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/reqId> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#FeedViewPost/reqId> rdfs:comment "reqId: Unique identifier per request that may be passed back alongside interactions." .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonReasonRepost> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonReasonRepost> rdfs:comment "FeedDefs_SkeletonReasonRepost is a "skeletonReasonRepost" in the app.bsky.feed.defs schema.
+
+RECORDTYPE: FeedDefs_SkeletonReasonRepost" .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonReasonRepost/repost> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonReasonRepost/repost> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#SkeletonReasonRepost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonReasonRepost/repost> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchStarterPack> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchStarterPack> rdfs:comment "UnspeccedDefs_SkeletonSearchStarterPack is a "skeletonSearchStarterPack" in the app.bsky.unspecced.defs schema." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchStarterPack/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchStarterPack/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchStarterPack> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#SkeletonSearchStarterPack/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.describeRepo#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.describeRepo#Main> rdfs:comment "Get information about an account and repository, including the list of collections. Does not require auth." .
+<https://atproto.social/ontology/app.bsky.actor.getPreferences#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.getPreferences#Main> rdfs:comment "Get private preferences attached to the current account. Expected use is synchronization between multiple devices, and import/export during account migration. Requires auth." .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata/messagesSent> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata/messagesSent> rdfs:domain <https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata> .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata/messagesSent> rdfs:range owl:Thing .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata/messagesReceived> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata/messagesReceived> rdfs:domain <https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata> .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata/messagesReceived> rdfs:range owl:Thing .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata/convos> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata/convos> rdfs:domain <https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata> .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata/convos> rdfs:range owl:Thing .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata/convosStarted> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata/convosStarted> rdfs:domain <https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata> .
+<https://atproto.social/ontology/chat.bsky.moderation.getActorMetadata#Metadata/convosStarted> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.moderation.defs#SubjectType> a owl:Class .
+<https://atproto.social/ontology/com.atproto.moderation.defs#SubjectType> rdfs:comment "Tag describing a type of subject that might be reported." .
+<https://atproto.social/ontology/app.bsky.feed.postgate#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.postgate#Main> rdfs:comment "Record defining interaction rules for a post. The record key (rkey) of the postgate record must match the record key of the post, and that record must be in the same repository." .
+<https://atproto.social/ontology/chat.bsky.convo.listConvos#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> rdfs:comment "Verification data for the associated subject." .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/subjectRepo> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/subjectRepo> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/subjectRepo> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/issuerRepo> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/issuerRepo> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/issuerRepo> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/subject> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/subject> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/subject> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/subject> rdfs:comment "The subject of the verification." .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/displayName> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/displayName> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/displayName> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/displayName> rdfs:comment "Display name of the subject the verification applies to at the moment of verifying, which might not be the same at the time of viewing. The verification is only valid if the current displayName matches the one at the time of verifying." .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/createdAt> rdfs:comment "Timestamp when the verification was created." .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/revokeReason> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/revokeReason> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/revokeReason> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/revokeReason> rdfs:comment "Describes the reason for revocation, also indicating that the verification is no longer valid." .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/revokedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/revokedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/revokedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/revokedAt> rdfs:comment "Timestamp when the verification was revoked." .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/subjectProfile> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/subjectProfile> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/subjectProfile> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/issuer> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/issuer> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/issuer> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/issuer> rdfs:comment "The user who issued this verification." .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/uri> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/uri> rdfs:comment "The AT-URI of the verification record." .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/handle> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/handle> rdfs:comment "Handle of the subject the verification applies to at the moment of verifying, which might not be the same at the time of viewing. The verification is only valid if the current handle matches the one at the time of verifying." .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/revokedBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/revokedBy> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/revokedBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/revokedBy> rdfs:comment "The user who revoked this verification." .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/issuerProfile> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/issuerProfile> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView> .
+<https://atproto.social/ontology/tools.ozone.verification.defs#VerificationView/issuerProfile> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.server.getAccountInviteCodes#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.getAccountInviteCodes#Main> rdfs:comment "Get all invite codes for the current account. Requires auth." .
+<https://atproto.social/ontology/tools.ozone.team.defs#RoleModerator> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.team.defs#RoleModerator> rdfs:comment "Moderator role. Can perform most actions." .
+<https://atproto.social/ontology/com.atproto.server.updateEmail#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.updateEmail#Main> rdfs:comment "Update an account's email." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewNotFound> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewNotFound/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewNotFound/did> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewNotFound> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewNotFound/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventAcknowledge> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventAcknowledge/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventAcknowledge/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventAcknowledge> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventAcknowledge/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventAcknowledge/acknowledgeAccountSubjects> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventAcknowledge/acknowledgeAccountSubjects> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventAcknowledge> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventAcknowledge/acknowledgeAccountSubjects> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventAcknowledge/acknowledgeAccountSubjects> rdfs:comment "If true, all other reports on content authored by this account will be resolved (acknowledged)." .
+<https://atproto.social/ontology/tools.ozone.moderation.getRecord#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.getRecord#Main> rdfs:comment "Get details about a record." .
+<https://atproto.social/ontology/app.bsky.graph.getActorStarterPacks#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getActorStarterPacks#Main> rdfs:comment "Get a list of starter packs created by the actor." .
+<https://atproto.social/ontology/com.atproto.admin.getInviteCodes#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.getInviteCodes#Main> rdfs:comment "Get an admin view of invite codes." .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Update> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Update> rdfs:comment "Operation which updates an existing record." .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Update/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Update/value> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#Update> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Update/value> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Update/collection> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Update/collection> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#Update> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Update/collection> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Update/rkey> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Update/rkey> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#Update> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#Update/rkey> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.defs#CommitMeta> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.defs#CommitMeta/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.defs#CommitMeta/cid> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.defs#CommitMeta> .
+<https://atproto.social/ontology/com.atproto.repo.defs#CommitMeta/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.defs#CommitMeta/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.defs#CommitMeta/rev> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.defs#CommitMeta> .
+<https://atproto.social/ontology/com.atproto.repo.defs#CommitMeta/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.getReporterStats#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.getReporterStats#Main> rdfs:comment "Get reporter stats for a list of users." .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/hostname> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/hostname> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.listHosts#Host> .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/hostname> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/hostname> rdfs:comment "hostname of server; not a URL (no scheme)" .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/seq> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/seq> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.listHosts#Host> .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/seq> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/seq> rdfs:comment "Recent repo stream event sequence number. May be delayed from actual stream processing (eg, persisted cursor not in-memory cursor)." .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/accountCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/accountCount> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.listHosts#Host> .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/accountCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/status> a owl:ObjectProperty .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/status> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.listHosts#Host> .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Host/status> rdfs:range <https://atproto.social/ontology/com.atproto.sync.listHosts#Com.atproto.sync.defs#hostStatus> .
+<https://atproto.social/ontology/tools.ozone.server.getConfig#ServiceConfig> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.server.getConfig#ServiceConfig/url> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.server.getConfig#ServiceConfig/url> rdfs:domain <https://atproto.social/ontology/tools.ozone.server.getConfig#ServiceConfig> .
+<https://atproto.social/ontology/tools.ozone.server.getConfig#ServiceConfig/url> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWordsPref> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWordsPref> rdfs:comment "ActorDefs_MutedWordsPref is a "mutedWordsPref" in the app.bsky.actor.defs schema.
+
+RECORDTYPE: ActorDefs_MutedWordsPref" .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWordsPref/items> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWordsPref/items> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#MutedWordsPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWordsPref/items> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#App.bsky.actor.defs#mutedWord> .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWordsPref/items> rdfs:comment "items: A list of words the account owner has muted." .
+<https://atproto.social/ontology/com.atproto.identity.submitPlcOperation#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.identity.submitPlcOperation#Main> rdfs:comment "Validates a PLC operation to ensure that it doesn't violate a service's constraints or get the identity into a bad state, then submits it to the PLC registry" .
+<https://atproto.social/ontology/com.atproto.moderation.createReport#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.moderation.createReport#Main> rdfs:comment "Submit a moderation report regarding an atproto account or record. Implemented by moderation services (with PDS proxying), and requires auth." .
+<https://atproto.social/ontology/com.atproto.repo.listMissingBlobs#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.listMissingBlobs#Main> rdfs:comment "Returns a list of missing blobs for the requesting account. Intended to be used in the account migration flow." .
+<https://atproto.social/ontology/com.atproto.sync.getBlocks#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.getBlocks#Main> rdfs:comment "Get data blocks from a given repo, by CID. For example, intermediate MST nodes, or records. Does not require auth; implemented by PDS." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/accountReportCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/accountReportCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/accountReportCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/accountReportCount> rdfs:comment "The total number of reports made by the user on accounts." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/reportedAccountCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/reportedAccountCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/reportedAccountCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/reportedAccountCount> rdfs:comment "The total number of accounts reported by the user." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/takendownAccountCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/takendownAccountCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/takendownAccountCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/takendownAccountCount> rdfs:comment "The total number of accounts taken down as a result of the user's reports." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/labeledRecordCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/labeledRecordCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/labeledRecordCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/labeledRecordCount> rdfs:comment "The total number of records labeled as a result of the user's reports." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/did> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/reportedRecordCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/reportedRecordCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/reportedRecordCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/reportedRecordCount> rdfs:comment "The total number of records reported by the user." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/takendownRecordCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/takendownRecordCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/takendownRecordCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/takendownRecordCount> rdfs:comment "The total number of records taken down as a result of the user's reports." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/labeledAccountCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/labeledAccountCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/labeledAccountCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/labeledAccountCount> rdfs:comment "The total number of accounts labeled as a result of the user's reports." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/recordReportCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/recordReportCount> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/recordReportCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReporterStats/recordReportCount> rdfs:comment "The total number of reports made by the user on records." .
+<https://atproto.social/ontology/app.bsky.embed.images#View> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.images#View> rdfs:comment "EmbedImages_View is a "view" in the app.bsky.embed.images schema.
+
+RECORDTYPE: EmbedImages_View" .
+<https://atproto.social/ontology/app.bsky.embed.images#View/images> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.images#View/images> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.images#View> .
+<https://atproto.social/ontology/app.bsky.embed.images#View/images> rdfs:range <https://atproto.social/ontology/app.bsky.embed.images#ViewImage> .
+<https://atproto.social/ontology/app.bsky.feed.generator#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.generator#Main> rdfs:comment "Record declaring of the existence of a feed generator, and containing metadata about it. The record can exist in any repository." .
+<https://atproto.social/ontology/app.bsky.feed.getAuthorFeed#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getAuthorFeed#Main> rdfs:comment "Get a view of an actor's 'author feed' (post and reposts by the author). Does not require auth." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp> rdfs:comment "A repo operation, ie a mutation of a single record." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/action> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/action> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/action> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/path> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/path> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/path> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/cid> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/cid> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/cid> rdfs:comment "For creates and updates, the new record CID. For deletions, null." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/prev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/prev> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/prev> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#RepoOp/prev> rdfs:comment "For updates and deletes, the previous record CID (required for inductive firehose). For creations, field should not be defined." .
+<https://atproto.social/ontology/app.bsky.feed.repost#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.repost#Main> rdfs:comment "Record representing a 'repost' of an existing Bluesky post." .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> a owl:Class .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> rdfs:comment "LabelerDefs_LabelerViewDetailed is a "labelerViewDetailed" in the app.bsky.labeler.defs schema.
+
+RECORDTYPE: LabelerDefs_LabelerViewDetailed" .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/reasonTypes> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/reasonTypes> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/reasonTypes> rdfs:range <https://atproto.social/ontology/app.bsky.labeler.defs#Com.atproto.moderation.defs#reasonType> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/reasonTypes> rdfs:comment "reasonTypes: The set of report reason 'codes' which are in-scope for this service to review and action. These usually align to policy categories. If not defined (distinct from empty array), all reason types are allowed." .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/subjectCollections> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/subjectCollections> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/subjectCollections> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/subjectCollections> rdfs:comment "subjectCollections: Set of record types (collection NSIDs) which can be reported to this service. If not defined (distinct from empty array), default is any record type." .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/creator> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/creator> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/creator> rdfs:range <https://atproto.social/ontology/app.bsky.labeler.defs#App.bsky.actor.defs#profileView> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/policies> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/policies> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/policies> rdfs:range <https://atproto.social/ontology/app.bsky.labeler.defs#App.bsky.labeler.defs#labelerPolicies> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/labels> rdfs:range <https://atproto.social/ontology/app.bsky.labeler.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/likeCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/likeCount> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/likeCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/viewer> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/viewer> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/viewer> rdfs:range <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewerState> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/subjectTypes> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/subjectTypes> rdfs:domain <https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/subjectTypes> rdfs:range <https://atproto.social/ontology/app.bsky.labeler.defs#Com.atproto.moderation.defs#subjectType> .
+<https://atproto.social/ontology/app.bsky.labeler.defs#LabelerViewDetailed/subjectTypes> rdfs:comment "subjectTypes: The set of subject types (account, record, etc) this service accepts reports on." .
+<https://atproto.social/ontology/com.atproto.admin.getSubjectStatus#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.getSubjectStatus#Main> rdfs:comment "Get the service-specific admin status of a subject (account, record, or blob)." .
+<https://atproto.social/ontology/com.atproto.temp.fetchLabels#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.temp.fetchLabels#Main> rdfs:comment "DEPRECATED: use queryLabels or subscribeLabels instead -- Fetch all labels from a labeler created after a certain date." .
+<https://atproto.social/ontology/com.atproto.admin.disableInviteCodes#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.disableInviteCodes#Main> rdfs:comment "Disable some set of codes and/or all codes associated with a set of users." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync> rdfs:comment "Updates the repo to a new state, without necessarily including that state on the firehose. Used to recover from broken commit streams, data loss incidents, or in situations where upstream host does not know recent state of the repository." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/seq> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/seq> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/seq> rdfs:range owl:Thing .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/seq> rdfs:comment "The stream sequence number of this message." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/did> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/did> rdfs:comment "The account this repo event corresponds to. Must match that in the commit object." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/blocks> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/blocks> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/blocks> rdfs:range xsd:base64Binary .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/blocks> rdfs:comment "CAR file containing the commit, as a block. The CAR header must include the commit block CID as the first 'root'." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/rev> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/rev> rdfs:comment "The rev of the commit. This value must match that in the commit object." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/time> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/time> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync> .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/time> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Sync/time> rdfs:comment "Timestamp of when this message was originally broadcast." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventPriorityScore> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventPriorityScore> rdfs:comment "Set priority score of the subject. Higher score means higher priority." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventPriorityScore/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventPriorityScore/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventPriorityScore> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventPriorityScore/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventPriorityScore/score> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventPriorityScore/score> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventPriorityScore> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ModEventPriorityScore/score> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.set.addValues#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.set.addValues#Main> rdfs:comment "Add values to a specific set. Attempting to add values to a set that does not exist will result in an error." .
+<https://atproto.social/ontology/app.bsky.embed.external#View> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.external#View> rdfs:comment "EmbedExternal_View is a "view" in the app.bsky.embed.external schema.
+
+RECORDTYPE: EmbedExternal_View" .
+<https://atproto.social/ontology/app.bsky.embed.external#View/external> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.external#View/external> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.external#View> .
+<https://atproto.social/ontology/app.bsky.embed.external#View/external> rdfs:range <https://atproto.social/ontology/app.bsky.embed.external#ViewExternal> .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Like> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Like> rdfs:comment "FeedGetLikes_Like is a "like" in the app.bsky.feed.getLikes schema." .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Like/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Like/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.getLikes#Like> .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Like/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Like/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Like/createdAt> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.getLikes#Like> .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Like/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Like/actor> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Like/actor> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.getLikes#Like> .
+<https://atproto.social/ontology/app.bsky.feed.getLikes#Like/actor> rdfs:range <https://atproto.social/ontology/app.bsky.feed.getLikes#App.bsky.actor.defs#profileView> .
+<https://atproto.social/ontology/app.bsky.graph.block#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.block#Main> rdfs:comment "Record declaring a 'block' relationship against another account. NOTE: blocks are public in Bluesky; see blog posts for details." .
+<https://atproto.social/ontology/app.bsky.unspecced.getTrends#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getTrends#Main> rdfs:comment "Get the current trends on the network" .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/head> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/head> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.listRepos#Repo> .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/head> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/head> rdfs:comment "Current repo commit CID" .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/rev> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.listRepos#Repo> .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/active> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/active> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.listRepos#Repo> .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/active> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/status> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/status> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.listRepos#Repo> .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/status> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/status> rdfs:comment "If active=false, this optional field indicates a possible reason for why the account is not active. If active=false and no status is supplied, then the host makes no claim for why the repository is no longer being hosted." .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/did> rdfs:domain <https://atproto.social/ontology/com.atproto.sync.listRepos#Repo> .
+<https://atproto.social/ontology/com.atproto.sync.listRepos#Repo/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectReviewState> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.updateAccountHandle#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.updateAccountHandle#Main> rdfs:comment "Administrative action to update an account's handle." .
+<https://atproto.social/ontology/tools.ozone.moderation.getSubjects#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.getSubjects#Main> rdfs:comment "Get details about subjects." .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult/uri> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult/cid> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult/validationStatus> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult/validationStatus> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult> .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#UpdateResult/validationStatus> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.confirmEmail#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.confirmEmail#Main> rdfs:comment "Confirm an email using a token from com.atproto.server.requestEmailConfirmation." .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCodeUse> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCodeUse/usedBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCodeUse/usedBy> rdfs:domain <https://atproto.social/ontology/com.atproto.server.defs#InviteCodeUse> .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCodeUse/usedBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCodeUse/usedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCodeUse/usedAt> rdfs:domain <https://atproto.social/ontology/com.atproto.server.defs#InviteCodeUse> .
+<https://atproto.social/ontology/com.atproto.server.defs#InviteCodeUse/usedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Links> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Links/privacyPolicy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Links/privacyPolicy> rdfs:domain <https://atproto.social/ontology/com.atproto.server.describeServer#Links> .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Links/privacyPolicy> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Links/termsOfService> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Links/termsOfService> rdfs:domain <https://atproto.social/ontology/com.atproto.server.describeServer#Links> .
+<https://atproto.social/ontology/com.atproto.server.describeServer#Links/termsOfService> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView> rdfs:comment "GraphDefs_ListView is a "listView" in the app.bsky.graph.defs schema.
+
+RECORDTYPE: GraphDefs_ListView" .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/name> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/name> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/name> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/purpose> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/purpose> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/purpose> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#ListPurpose> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/descriptionFacets> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/descriptionFacets> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/descriptionFacets> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#App.bsky.richtext.facet> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/labels> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/viewer> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/viewer> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/viewer> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#ListViewerState> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/creator> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/creator> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/creator> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#App.bsky.actor.defs#profileView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/description> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/description> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/description> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/avatar> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/avatar> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/avatar> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/listItemCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/listItemCount> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#ListView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#ListView/listItemCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.graph.follow#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.follow#Main> rdfs:comment "Record declaring a social 'follow' relationship of another account. Duplicate follows will be ignored by the AppView." .
+<https://atproto.social/ontology/chat.bsky.convo.getLog#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.identity.refreshIdentity#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.identity.refreshIdentity#Main> rdfs:comment "Request that the server re-resolve an identity (DID and handle). The server may ignore this request, or require authentication, depending on the role, implementation, and policy of the server." .
+<https://atproto.social/ontology/com.atproto.sync.getBlob#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.getBlob#Main> rdfs:comment "Get a blob associated with a given account. Returns the full blob as originally uploaded. Does not require auth; implemented by PDS." .
+<https://atproto.social/ontology/com.atproto.sync.getHead#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.getHead#Main> rdfs:comment "DEPRECATED - please use com.atproto.sync.getLatestCommit instead" .
+<https://atproto.social/ontology/app.bsky.actor.defs#KnownFollowers> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#KnownFollowers> rdfs:comment "ActorDefs_KnownFollowers is a "knownFollowers" in the app.bsky.actor.defs schema.
+
+The subject's followers whom you also follow" .
+<https://atproto.social/ontology/app.bsky.actor.defs#KnownFollowers/count> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#KnownFollowers/count> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#KnownFollowers> .
+<https://atproto.social/ontology/app.bsky.actor.defs#KnownFollowers/count> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#KnownFollowers/followers> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#KnownFollowers/followers> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#KnownFollowers> .
+<https://atproto.social/ontology/app.bsky.actor.defs#KnownFollowers/followers> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/com.atproto.server.activateAccount#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.activateAccount#Main> rdfs:comment "Activates a currently deactivated account. Used to finalize account migration after the account's repo is imported and identity is setup." .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.listHosts#Main> rdfs:comment "Enumerates upstream hosts (eg, PDS or relay instances) that this service consumes from. Implemented by relays." .
+<https://atproto.social/ontology/tools.ozone.communication.updateTemplate#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.communication.updateTemplate#Main> rdfs:comment "Administrative action to update an existing communication template. Allows passing partial fields to patch specific fields only." .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView> rdfs:comment "ActorDefs_StatusView is a "statusView" in the app.bsky.actor.defs schema." .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/expiresAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/expiresAt> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#StatusView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/expiresAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/expiresAt> rdfs:comment "expiresAt: The date when this status will expire. The application might choose to no longer return the status after expiration." .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/isActive> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/isActive> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#StatusView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/isActive> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/isActive> rdfs:comment "isActive: True if the status is not expired, false if it is expired. Only present if expiration was set." .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/status> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/status> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#StatusView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/status> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/status> rdfs:comment "status: The status for the account." .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/record> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/record> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#StatusView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/record> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/embed> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/embed> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#StatusView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/embed> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#StatusView/embed> rdfs:comment "embed: An optional embed associated with the status." .
+<https://atproto.social/ontology/app.bsky.notification.defs#RecordDeleted> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.defs#RecordDeleted> rdfs:comment "NotificationDefs_RecordDeleted is a "recordDeleted" in the app.bsky.notification.defs schema." .
+<https://atproto.social/ontology/chat.bsky.convo.unmuteConvo#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.temp.addReservedHandle#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.temp.addReservedHandle#Main> rdfs:comment "Add a handle to the set of reserved handles." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReviewNone> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReviewNone> rdfs:comment "Moderator review status of a subject: Unnecessary. Indicates that the subject does not need a review at the moment but there is probably some moderation related metadata available for it" .
+<https://atproto.social/ontology/app.bsky.feed.getSuggestedFeeds#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getSuggestedFeeds#Main> rdfs:comment "Get a list of suggested feeds (feed generators) for the requesting account." .
+<https://atproto.social/ontology/app.bsky.notification.updateSeen#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.updateSeen#Main> rdfs:comment "Notify server that the requesting account has seen notifications. Requires auth." .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestedFeeds#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getSuggestedFeeds#Main> rdfs:comment "Get a list of suggested feeds" .
+<https://atproto.social/ontology/com.atproto.repo.listMissingBlobs#RecordBlob> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.listMissingBlobs#RecordBlob/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.listMissingBlobs#RecordBlob/cid> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.listMissingBlobs#RecordBlob> .
+<https://atproto.social/ontology/com.atproto.repo.listMissingBlobs#RecordBlob/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.repo.listMissingBlobs#RecordBlob/recordUri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.repo.listMissingBlobs#RecordBlob/recordUri> rdfs:domain <https://atproto.social/ontology/com.atproto.repo.listMissingBlobs#RecordBlob> .
+<https://atproto.social/ontology/com.atproto.repo.listMissingBlobs#RecordBlob/recordUri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref> rdfs:comment "ActorDefs_FeedViewPref is a "feedViewPref" in the app.bsky.actor.defs schema.
+
+RECORDTYPE: ActorDefs_FeedViewPref" .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/feed> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/feed> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/feed> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/feed> rdfs:comment "feed: The URI of the feed, or an identifier which describes the feed." .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideReplies> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideReplies> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideReplies> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideReplies> rdfs:comment "hideReplies: Hide replies in the feed." .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideRepliesByUnfollowed> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideRepliesByUnfollowed> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideRepliesByUnfollowed> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideRepliesByUnfollowed> rdfs:comment "hideRepliesByUnfollowed: Hide replies in the feed if they are not by followed users." .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideRepliesByLikeCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideRepliesByLikeCount> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideRepliesByLikeCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideRepliesByLikeCount> rdfs:comment "hideRepliesByLikeCount: Hide replies in the feed if they do not have this number of likes." .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideReposts> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideReposts> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideReposts> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideReposts> rdfs:comment "hideReposts: Hide reposts in the feed." .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideQuotePosts> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideQuotePosts> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideQuotePosts> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.actor.defs#FeedViewPref/hideQuotePosts> rdfs:comment "hideQuotePosts: Hide quote posts in the feed." .
+<https://atproto.social/ontology/app.bsky.feed.getFeedGenerators#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getFeedGenerators#Main> rdfs:comment "Get information about a list of feed generators." .
+<https://atproto.social/ontology/app.bsky.feed.getFeedSkeleton#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getFeedSkeleton#Main> rdfs:comment "Get a skeleton of a feed provided by a feed generator. Auth is optional, depending on provider requirements, and provides the DID of the requester. Implemented by Feed Generator Service." .
+<https://atproto.social/ontology/com.atproto.identity.requestPlcOperationSignature#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.identity.requestPlcOperationSignature#Main> rdfs:comment "Request an email with a code to in order to request a signed PLC operation. Requires Auth." .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.createAppPassword#Main> rdfs:comment "Create an App Password." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ImageDetails> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ImageDetails/height> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ImageDetails/height> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ImageDetails> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ImageDetails/height> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ImageDetails/width> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ImageDetails/width> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#ImageDetails> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ImageDetails/width> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.team.defs#RoleAdmin> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.team.defs#RoleAdmin> rdfs:comment "Admin role. Highest level of access, can perform all actions." .
+<https://atproto.social/ontology/app.bsky.embed.external#External> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.external#External> rdfs:comment "EmbedExternal_External is a "external" in the app.bsky.embed.external schema." .
+<https://atproto.social/ontology/app.bsky.embed.external#External/thumb> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.external#External/thumb> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.external#External> .
+<https://atproto.social/ontology/app.bsky.embed.external#External/thumb> rdfs:range xsd:base64Binary .
+<https://atproto.social/ontology/app.bsky.embed.external#External/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.external#External/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.external#External> .
+<https://atproto.social/ontology/app.bsky.embed.external#External/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.external#External/title> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.external#External/title> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.external#External> .
+<https://atproto.social/ontology/app.bsky.embed.external#External/title> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.external#External/description> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.external#External/description> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.external#External> .
+<https://atproto.social/ontology/app.bsky.embed.external#External/description> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#InteractionReply> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#InteractionReply> rdfs:comment "User replied to the feed item" .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship> rdfs:comment "GraphDefs_Relationship is a "relationship" in the app.bsky.graph.defs schema.
+
+lists the bi-directional graph relationships between one actor (not indicated in the object), and the target actors (the DID included in the object)
+
+RECORDTYPE: GraphDefs_Relationship" .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship/did> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#Relationship> .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship/following> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship/following> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#Relationship> .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship/following> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship/following> rdfs:comment "following: if the actor follows this DID, this is the AT-URI of the follow record" .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship/followedBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship/followedBy> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#Relationship> .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship/followedBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#Relationship/followedBy> rdfs:comment "followedBy: if the actor is followed by this DID, contains the AT-URI of the follow record" .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionViewSender> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionViewSender/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionViewSender/did> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#ReactionViewSender> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ReactionViewSender/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.listVerifications#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.verification.listVerifications#Main> rdfs:comment "List verifications" .
+<https://atproto.social/ontology/app.bsky.actor.defs#PostInteractionSettingsPref> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#PostInteractionSettingsPref> rdfs:comment "ActorDefs_PostInteractionSettingsPref is a "postInteractionSettingsPref" in the app.bsky.actor.defs schema.
+
+Default post interaction settings for the account. These values should be applied as default values when creating new posts. These refs should mirror the threadgate and postgate records exactly.
+
+RECORDTYPE: ActorDefs_PostInteractionSettingsPref" .
+<https://atproto.social/ontology/app.bsky.actor.defs#PostInteractionSettingsPref/threadgateAllowRules> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#PostInteractionSettingsPref/threadgateAllowRules> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#PostInteractionSettingsPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#PostInteractionSettingsPref/threadgateAllowRules> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#PostInteractionSettingsPref/threadgateAllowRules> rdfs:comment "threadgateAllowRules: Matches threadgate record. List of rules defining who can reply to this users posts. If value is an empty array, no one can reply. If value is undefined, anyone can reply." .
+<https://atproto.social/ontology/app.bsky.actor.defs#PostInteractionSettingsPref/postgateEmbeddingRules> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#PostInteractionSettingsPref/postgateEmbeddingRules> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#PostInteractionSettingsPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#PostInteractionSettingsPref/postgateEmbeddingRules> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#PostInteractionSettingsPref/postgateEmbeddingRules> rdfs:comment "postgateEmbeddingRules: Matches postgate record. List of rules defining who can embed this users posts. If value is an empty array or is undefined, no particular rules apply and anyone can embed." .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.threadgate#Main> rdfs:comment "Record defining interaction gating rules for a thread (aka, reply controls). The record key (rkey) of the threadgate record must match the record key of the thread's root post, and that record must be in the same repository." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReviewOpen> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReviewOpen> rdfs:comment "Moderator review status of a subject: Open. Indicates that the subject needs to be reviewed by a moderator" .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView> rdfs:comment "Detailed view of a subject. For record subjects, the author's repo and profile will be returned." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/type> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/type> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/type> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#Com.atproto.moderation.defs#subjectType> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/subject> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/subject> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/subject> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/status> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/status> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/status> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectStatusView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/repo> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/repo> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/repo> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#RepoViewDetail> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/profile> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/profile> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/profile> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/record> a owl:ObjectProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/record> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#SubjectView/record> rdfs:range <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewDetail> .
+<https://atproto.social/ontology/app.bsky.graph.muteActor#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.muteActor#Main> rdfs:comment "Creates a mute relationship for the specified account. Mutes are private in Bluesky. Requires auth." .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem> rdfs:comment "UnspeccedGetPostThreadOtherV2_ThreadItem is a "threadItem" in the app.bsky.unspecced.getPostThreadOtherV2 schema." .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem> .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem/depth> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem/depth> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem> .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem/depth> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem/depth> rdfs:comment "depth: The nesting level of this item in the thread. Depth 0 means the anchor item. Items above have negative depths, items below have positive depths." .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem/value> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem/value> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem> .
+<https://atproto.social/ontology/app.bsky.unspecced.getPostThreadOtherV2#ThreadItem/value> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewNotFound> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewNotFound/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewNotFound/uri> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewNotFound> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordViewNotFound/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting/deletedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting/deletedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting/deletedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting/status> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting/status> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting/status> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting/updatedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting/updatedAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting/updatedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#RecordHosting/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.getListFeed#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getListFeed#Main> rdfs:comment "Get a feed of recent posts from a list (posts and reposts from any actors on the list). Does not require auth." .
+<https://atproto.social/ontology/app.bsky.feed.getRepostedBy#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getRepostedBy#Main> rdfs:comment "Get a list of reposts for a given post." .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#EmailUpdated> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#EmailUpdated/email> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#EmailUpdated/email> rdfs:domain <https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#EmailUpdated> .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#EmailUpdated/email> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.signature.searchAccounts#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.signature.searchAccounts#Main> rdfs:comment "Search for accounts that match one or more threat signature values." .
+<https://atproto.social/ontology/app.bsky.actor.defs#LabelerPrefItem> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#LabelerPrefItem> rdfs:comment "ActorDefs_LabelerPrefItem is a "labelerPrefItem" in the app.bsky.actor.defs schema." .
+<https://atproto.social/ontology/app.bsky.actor.defs#LabelerPrefItem/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#LabelerPrefItem/did> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#LabelerPrefItem> .
+<https://atproto.social/ontology/app.bsky.actor.defs#LabelerPrefItem/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.images#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.images#Main/images> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.embed.images#Main/images> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.images#Main> .
+<https://atproto.social/ontology/app.bsky.embed.images#Main/images> rdfs:range <https://atproto.social/ontology/app.bsky.embed.images#Image> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef> rdfs:comment "FeedDefs_ReplyRef is a "replyRef" in the app.bsky.feed.defs schema." .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef/root> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef/root> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef/root> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef/parent> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef/parent> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef/parent> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef/grandparentAuthor> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef/grandparentAuthor> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef/grandparentAuthor> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#App.bsky.actor.defs#profileViewBasic> .
+<https://atproto.social/ontology/app.bsky.feed.defs#ReplyRef/grandparentAuthor> rdfs:comment "grandparentAuthor: When parent is a reply to another post, this is the author of that post." .
+<https://atproto.social/ontology/app.bsky.feed.getFeed#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getFeed#Main> rdfs:comment "Get a hydrated feed from an actor's selected feed generator. Implemented by App View." .
+<https://atproto.social/ontology/app.bsky.graph.getBlocks#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getBlocks#Main> rdfs:comment "Enumerates which accounts the requesting account is currently blocking. Requires auth." .
+<https://atproto.social/ontology/app.bsky.graph.listblock#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.listblock#Main> rdfs:comment "Record representing a block relationship against an entire an entire list of accounts (actors)." .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.sync.subscribeRepos#Main> rdfs:comment "Repository event stream, aka Firehose endpoint. Outputs repo commits with diff data, and identity update events, for all repositories on the current server. See the atproto specifications for details around stream sequencing, repo versioning, CAR diff format, and more. Public and does not require auth; implemented by PDS and Relay." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReviewClosed> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#ReviewClosed> rdfs:comment "Moderator review status of a subject: Closed. Indicates that the subject was already reviewed and resolved by a moderator" .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef> a owl:Class .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef/did> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef> .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef/cid> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef> .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef/recordUri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef/recordUri> rdfs:domain <https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef> .
+<https://atproto.social/ontology/com.atproto.admin.defs#RepoBlobRef/recordUri> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.label.subscribeLabels#Main> rdfs:comment "Subscribe to stream of labels (and negations). Public endpoint implemented by mod services. Uses same sequencing scheme as repo event stream." .
+<https://atproto.social/ontology/com.atproto.repo.importRepo#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.importRepo#Main> rdfs:comment "Import a repo in the form of a CAR file. Requires Content-Length HTTP header to be set." .
+<https://atproto.social/ontology/com.atproto.server.resetPassword#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.resetPassword#Main> rdfs:comment "Reset a user account password using a token." .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewNotFound> a owl:Class .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewNotFound> rdfs:comment "EmbedRecord_ViewNotFound is a "viewNotFound" in the app.bsky.embed.record schema.
+
+RECORDTYPE: EmbedRecord_ViewNotFound" .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewNotFound/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewNotFound/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewNotFound> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewNotFound/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewNotFound/notFound> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewNotFound/notFound> rdfs:domain <https://atproto.social/ontology/app.bsky.embed.record#ViewNotFound> .
+<https://atproto.social/ontology/app.bsky.embed.record#ViewNotFound/notFound> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.graph.getLists#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getLists#Main> rdfs:comment "Enumerates the lists created by a specified account (actor)." .
+<https://atproto.social/ontology/app.bsky.unspecced.searchActorsSkeleton#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.searchActorsSkeleton#Main> rdfs:comment "Backend Actors (profile) search, returns only skeleton." .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/id> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/id> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/id> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/members> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/members> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/members> rdfs:range <https://atproto.social/ontology/chat.bsky.convo.defs#Chat.bsky.actor.defs#profileViewBasic> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/lastMessage> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/lastMessage> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/lastMessage> rdfs:range owl:Thing .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/lastReaction> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/lastReaction> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/lastReaction> rdfs:range owl:Thing .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/muted> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/muted> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/muted> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/status> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/status> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/status> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/unreadCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/unreadCount> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#ConvoView/unreadCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/facets> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/facets> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/facets> rdfs:range <https://atproto.social/ontology/chat.bsky.convo.defs#App.bsky.richtext.facet> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/facets> rdfs:comment "Annotations of text (mentions, URLs, hashtags, etc)" .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/embed> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/embed> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/embed> rdfs:range owl:Thing .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/reactions> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/reactions> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/reactions> rdfs:range <https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/reactions> rdfs:comment "Reactions to this message, in ascending order of creation time." .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/sender> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/sender> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/sender> rdfs:range <https://atproto.social/ontology/chat.bsky.convo.defs#MessageViewSender> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/sentAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/sentAt> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/sentAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/id> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/id> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/id> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/text> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/text> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#MessageView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#MessageView/text> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.temp.checkSignupQueue#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.temp.checkSignupQueue#Main> rdfs:comment "Check accounts location in signup queue." .
+<https://atproto.social/ontology/app.bsky.feed.getPostThread#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.getPostThread#Main> rdfs:comment "Get posts in a thread. Does not require auth, but additional metadata and filtering will be applied for authed requests." .
+<https://atproto.social/ontology/app.bsky.graph.getStarterPacks#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.getStarterPacks#Main> rdfs:comment "Get views for a list of starter packs." .
+<https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> rdfs:comment "NotificationDefs_FilterablePreference is a "filterablePreference" in the app.bsky.notification.defs schema." .
+<https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference/include> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference/include> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference/include> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference/list> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference/list> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference/list> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference/push> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference/push> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference> .
+<https://atproto.social/ontology/app.bsky.notification.defs#FilterablePreference/push> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.unspecced.getTrendsSkeleton#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.getTrendsSkeleton#Main> rdfs:comment "Get the skeleton of trends on the network. Intended to be called and then hydrated through app.bsky.unspecced.getTrends" .
+<https://atproto.social/ontology/app.bsky.actor.defs#MutedWordTarget> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#PersonalDetailsPref> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#PersonalDetailsPref> rdfs:comment "ActorDefs_PersonalDetailsPref is a "personalDetailsPref" in the app.bsky.actor.defs schema.
+
+RECORDTYPE: ActorDefs_PersonalDetailsPref" .
+<https://atproto.social/ontology/app.bsky.actor.defs#PersonalDetailsPref/birthDate> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#PersonalDetailsPref/birthDate> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#PersonalDetailsPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#PersonalDetailsPref/birthDate> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#PersonalDetailsPref/birthDate> rdfs:comment "birthDate: The birth date of account owner." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent> rdfs:comment "Logs account status related events on a repo subject. Normally captured by automod from the firehose and emitted to ozone for historical tracking." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/comment> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/comment> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/comment> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/active> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/active> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/active> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/active> rdfs:comment "Indicates that the account has a repository which can be fetched from the host that emitted this event." .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/status> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/status> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/status> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/timestamp> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/timestamp> rdfs:domain <https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent> .
+<https://atproto.social/ontology/tools.ozone.moderation.defs#AccountEvent/timestamp> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.moderation.getRepos#Main> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.moderation.getRepos#Main> rdfs:comment "Get details about some repositories." .
+<https://atproto.social/ontology/app.bsky.notification.registerPush#Main> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.registerPush#Main> rdfs:comment "Register to receive push notifications, via a specified service, for the requesting account. Requires auth." .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction/message> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction/message> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction/message> rdfs:range owl:Thing .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction/reaction> a owl:ObjectProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction/reaction> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction/reaction> rdfs:range <https://atproto.social/ontology/chat.bsky.convo.defs#ReactionView> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction/convoId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction/convoId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAddReaction/convoId> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.getMessages#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.repo.applyWrites#DeleteResult> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> rdfs:comment "ActorDefs_ProfileViewBasic is a "profileViewBasic" in the app.bsky.actor.defs schema." .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/verification> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/verification> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/verification> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#VerificationState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/avatar> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/avatar> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/avatar> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/viewer> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/viewer> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/viewer> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/displayName> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/displayName> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/displayName> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/associated> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/associated> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/associated> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#ProfileAssociated> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/labels> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/createdAt> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/createdAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/status> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/status> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/status> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#StatusView> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/did> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/did> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/did> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/handle> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/handle> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ProfileViewBasic/handle> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> rdfs:comment "ActorDefs_ViewerState is a "viewerState" in the app.bsky.actor.defs schema.
+
+Metadata about the requesting account's relationship with the subject account. Only has meaningful content for authed requests." .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/muted> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/muted> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/muted> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/mutedByList> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/mutedByList> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/mutedByList> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#App.bsky.graph.defs#listViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/blocking> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/blocking> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/blocking> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/blockingByList> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/blockingByList> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/blockingByList> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#App.bsky.graph.defs#listViewBasic> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/followedBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/followedBy> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/followedBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/knownFollowers> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/knownFollowers> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/knownFollowers> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#KnownFollowers> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/blockedBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/blockedBy> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/blockedBy> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/following> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/following> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/following> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/activitySubscription> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/activitySubscription> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#ViewerState> .
+<https://atproto.social/ontology/app.bsky.actor.defs#ViewerState/activitySubscription> rdfs:range <https://atproto.social/ontology/app.bsky.actor.defs#App.bsky.notification.defs#activitySubscription> .
+<https://atproto.social/ontology/app.bsky.feed.defs#InteractionShare> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#InteractionShare> rdfs:comment "User shared the feed item" .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> a owl:Class .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> rdfs:comment "GraphDefs_StarterPackView is a "starterPackView" in the app.bsky.graph.defs schema." .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/labels> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/labels> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/labels> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#Com.atproto.label.defs#label> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/indexedAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/indexedAt> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/indexedAt> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/record> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/record> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/record> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/list> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/list> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/list> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#ListViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/listItemsSample> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/listItemsSample> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/listItemsSample> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#ListItemView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/feeds> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/feeds> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/feeds> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#App.bsky.feed.defs#generatorView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/joinedAllTimeCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/joinedAllTimeCount> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/joinedAllTimeCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/cid> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/cid> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/cid> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/creator> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/creator> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/creator> rdfs:range <https://atproto.social/ontology/app.bsky.graph.defs#App.bsky.actor.defs#profileViewBasic> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/joinedWeekCount> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/joinedWeekCount> rdfs:domain <https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView> .
+<https://atproto.social/ontology/app.bsky.graph.defs#StarterPackView/joinedWeekCount> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#GrantError> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#GrantError> rdfs:comment "Error object for failed verifications." .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#GrantError/error> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#GrantError/error> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.grantVerifications#GrantError> .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#GrantError/error> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#GrantError/error> rdfs:comment "Error message describing the reason for failure." .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#GrantError/subject> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#GrantError/subject> rdfs:domain <https://atproto.social/ontology/tools.ozone.verification.grantVerifications#GrantError> .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#GrantError/subject> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.verification.grantVerifications#GrantError/subject> rdfs:comment "The did of the subject being verified" .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonReasonPin> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#SkeletonReasonPin> rdfs:comment "FeedDefs_SkeletonReasonPin is a "skeletonReasonPin" in the app.bsky.feed.defs schema.
+
+RECORDTYPE: FeedDefs_SkeletonReasonPin" .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAcceptConvo> a owl:Class .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAcceptConvo/rev> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAcceptConvo/rev> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogAcceptConvo> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAcceptConvo/rev> rdfs:range xsd:string .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAcceptConvo/convoId> a owl:DatatypeProperty .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAcceptConvo/convoId> rdfs:domain <https://atproto.social/ontology/chat.bsky.convo.defs#LogAcceptConvo> .
+<https://atproto.social/ontology/chat.bsky.convo.defs#LogAcceptConvo/convoId> rdfs:range xsd:string .
+<https://atproto.social/ontology/com.atproto.lexicon.schema#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.lexicon.schema#Main> rdfs:comment "Representation of Lexicon schemas themselves, when published as atproto records. Note that the schema language is not defined in Lexicon; this meta schema currently only includes a single version field ('lexicon'). See the atproto specifications for description of the other expected top-level fields ('id', 'defs', etc)." .
+<https://atproto.social/ontology/com.atproto.server.requestEmailConfirmation#Main> a owl:Class .
+<https://atproto.social/ontology/com.atproto.server.requestEmailConfirmation#Main> rdfs:comment "Request an email with a code to confirm ownership of email." .
+<https://atproto.social/ontology/app.bsky.actor.defs#HiddenPostsPref> a owl:Class .
+<https://atproto.social/ontology/app.bsky.actor.defs#HiddenPostsPref> rdfs:comment "ActorDefs_HiddenPostsPref is a "hiddenPostsPref" in the app.bsky.actor.defs schema.
+
+RECORDTYPE: ActorDefs_HiddenPostsPref" .
+<https://atproto.social/ontology/app.bsky.actor.defs#HiddenPostsPref/items> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.actor.defs#HiddenPostsPref/items> rdfs:domain <https://atproto.social/ontology/app.bsky.actor.defs#HiddenPostsPref> .
+<https://atproto.social/ontology/app.bsky.actor.defs#HiddenPostsPref/items> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.actor.defs#HiddenPostsPref/items> rdfs:comment "items: A list of URIs of posts the account owner has hidden." .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost> a owl:Class .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost> rdfs:comment "FeedDefs_BlockedPost is a "blockedPost" in the app.bsky.feed.defs schema.
+
+RECORDTYPE: FeedDefs_BlockedPost" .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost/uri> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost/uri> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost/uri> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost/blocked> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost/blocked> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost/blocked> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost/author> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost/author> rdfs:domain <https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost> .
+<https://atproto.social/ontology/app.bsky.feed.defs#BlockedPost/author> rdfs:range <https://atproto.social/ontology/app.bsky.feed.defs#BlockedAuthor> .
+<https://atproto.social/ontology/app.bsky.notification.defs#SubjectActivitySubscription> a owl:Class .
+<https://atproto.social/ontology/app.bsky.notification.defs#SubjectActivitySubscription> rdfs:comment "NotificationDefs_SubjectActivitySubscription is a "subjectActivitySubscription" in the app.bsky.notification.defs schema.
+
+Object used to store activity subscription data in stash." .
+<https://atproto.social/ontology/app.bsky.notification.defs#SubjectActivitySubscription/subject> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#SubjectActivitySubscription/subject> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#SubjectActivitySubscription> .
+<https://atproto.social/ontology/app.bsky.notification.defs#SubjectActivitySubscription/subject> rdfs:range xsd:string .
+<https://atproto.social/ontology/app.bsky.notification.defs#SubjectActivitySubscription/activitySubscription> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.notification.defs#SubjectActivitySubscription/activitySubscription> rdfs:domain <https://atproto.social/ontology/app.bsky.notification.defs#SubjectActivitySubscription> .
+<https://atproto.social/ontology/app.bsky.notification.defs#SubjectActivitySubscription/activitySubscription> rdfs:range <https://atproto.social/ontology/app.bsky.notification.defs#ActivitySubscription> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost> a owl:Class .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost> rdfs:comment "UnspeccedDefs_ThreadItemPost is a "threadItemPost" in the app.bsky.unspecced.defs schema.
+
+RECORDTYPE: UnspeccedDefs_ThreadItemPost" .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/mutedByViewer> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/mutedByViewer> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/mutedByViewer> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/mutedByViewer> rdfs:comment "mutedByViewer: This is by an account muted by the viewer requesting it." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/post> a owl:ObjectProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/post> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/post> rdfs:range <https://atproto.social/ontology/app.bsky.unspecced.defs#App.bsky.feed.defs#postView> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/moreParents> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/moreParents> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/moreParents> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/moreParents> rdfs:comment "moreParents: This post has more parents that were not present in the response. This is just a boolean, without the number of parents." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/moreReplies> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/moreReplies> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/moreReplies> rdfs:range owl:Thing .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/moreReplies> rdfs:comment "moreReplies: This post has more replies that were not present in the response. This is a numeric value, which is best-effort and might not be accurate." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/opThread> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/opThread> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/opThread> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/opThread> rdfs:comment "opThread: This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread." .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/hiddenByThreadgate> a owl:DatatypeProperty .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/hiddenByThreadgate> rdfs:domain <https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost> .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/hiddenByThreadgate> rdfs:range xsd:boolean .
+<https://atproto.social/ontology/app.bsky.unspecced.defs#ThreadItemPost/hiddenByThreadgate> rdfs:comment "hiddenByThreadgate: The threadgate created by the author indicates this post as a reply to be hidden for everyone consuming the thread." .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event> a owl:Class .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event/details> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event/details> rdfs:domain <https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event> .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event/details> rdfs:range owl:Thing .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event/createdBy> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event/createdBy> rdfs:domain <https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event> .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event/createdBy> rdfs:range xsd:string .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event/createdAt> a owl:DatatypeProperty .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event/createdAt> rdfs:domain <https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event> .
+<https://atproto.social/ontology/tools.ozone.hosting.getAccountHistory#Event/createdAt> rdfs:range xsd:string .

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module atprotontology
+
+go 1.23.8

--- a/main.go
+++ b/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+    "flag"
+    "fmt"
+    "log"
+
+    "atprotontology/ontology"
+)
+
+func main() {
+    emit := flag.Bool("emit-ontology", false, "generate ontology")
+    doc := flag.Bool("doc-reflection", false, "print doc reflection")
+    flag.Parse()
+
+    if *emit {
+        pipe := ontology.NewOntologyPipeline()
+        out := "build/lexicon.ttl"
+        if err := pipe.Run(".", out); err != nil {
+            log.Fatalf("pipeline error: %v", err)
+        }
+        fmt.Println("ontology written to", out)
+    }
+
+    if *doc {
+        pipe := ontology.NewOntologyPipeline()
+        if err := pipe.Godoc.Load("indigo/api/bsky"); err != nil {
+            log.Fatal(err)
+        }
+        for k, v := range pipe.Godoc.Docs {
+            fmt.Printf("%s: %s\n", k, v)
+        }
+    }
+}

--- a/ontology/godoc.go
+++ b/ontology/godoc.go
@@ -1,0 +1,51 @@
+package ontology
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+)
+
+// GodocAgent extracts documentation from Go source.
+type GodocAgent struct {
+	Docs map[string]string
+}
+
+func NewGodocAgent() *GodocAgent { return &GodocAgent{Docs: map[string]string{}} }
+
+func (g *GodocAgent) Load(dir string) error {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, nil, parser.ParseComments)
+	if err != nil {
+		return err
+	}
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				gd, ok := decl.(*ast.GenDecl)
+				if !ok || gd.Tok != token.TYPE {
+					continue
+				}
+				for _, spec := range gd.Specs {
+					ts := spec.(*ast.TypeSpec)
+					doc := ts.Doc
+					if doc == nil {
+						doc = gd.Doc
+					}
+					if doc != nil {
+						g.Docs[ts.Name.Name] = doc.Text()
+					}
+					if st, ok := ts.Type.(*ast.StructType); ok {
+						for _, f := range st.Fields.List {
+							if f.Doc != nil && len(f.Names) > 0 {
+								key := ts.Name.Name + "." + f.Names[0].Name
+								g.Docs[key] = f.Doc.Text()
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/ontology/goreflect.go
+++ b/ontology/goreflect.go
@@ -1,0 +1,65 @@
+package ontology
+
+import (
+    "go/ast"
+    "go/parser"
+    "go/token"
+)
+
+// GoStruct represents a Go struct with fields.
+type GoStruct struct {
+    Name   string
+    Fields []GoField
+}
+
+type GoField struct {
+    Name string
+    Type string
+    Tag  string
+}
+
+// GoReflectAgent parses Go structs.
+type GoReflectAgent struct {
+    Structs map[string]GoStruct
+}
+
+func NewGoReflectAgent() *GoReflectAgent { return &GoReflectAgent{Structs: map[string]GoStruct{}} }
+
+func (g *GoReflectAgent) Load(dir string) error {
+    fset := token.NewFileSet()
+    pkgs, err := parser.ParseDir(fset, dir, nil, parser.ParseComments)
+    if err != nil { return err }
+    for _, pkg := range pkgs {
+        for _, file := range pkg.Files {
+            for _, decl := range file.Decls {
+                gd, ok := decl.(*ast.GenDecl)
+                if !ok || gd.Tok != token.TYPE { continue }
+                for _, spec := range gd.Specs {
+                    ts := spec.(*ast.TypeSpec)
+                    st, ok := ts.Type.(*ast.StructType)
+                    if !ok { continue }
+                    gs := GoStruct{Name: ts.Name.Name}
+                    for _, f := range st.Fields.List {
+                        t := ""
+                        if se, ok := f.Type.(*ast.Ident); ok {
+                            t = se.Name
+                        } else if se, ok := f.Type.(*ast.ArrayType); ok {
+                            if id, ok := se.Elt.(*ast.Ident); ok {
+                                t = "[]" + id.Name
+                            }
+                        }
+                        tag := ""
+                        if f.Tag != nil {
+                            tag = f.Tag.Value
+                        }
+                        for _, name := range f.Names {
+                            gs.Fields = append(gs.Fields, GoField{Name: name.Name, Type: t, Tag: tag})
+                        }
+                    }
+                    g.Structs[gs.Name] = gs
+                }
+            }
+        }
+    }
+    return nil
+}

--- a/ontology/irimapper.go
+++ b/ontology/irimapper.go
@@ -1,0 +1,40 @@
+package ontology
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IRIMapperAgent generates IRIs and optional doc URLs.
+type IRIMapperAgent struct {
+	Prefix *PrefixAgent
+}
+
+func NewIRIMapperAgent(p *PrefixAgent) *IRIMapperAgent {
+	return &IRIMapperAgent{Prefix: p}
+}
+
+func toPascal(s string) string {
+	if s == "" {
+		return s
+	}
+	parts := strings.Split(s, "_")
+	if len(parts) == 1 {
+		parts = strings.Split(s, "-")
+	}
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, "")
+}
+
+func (m *IRIMapperAgent) ClassIRI(lexID, name string) string {
+	return m.Prefix.IRI("bsky", fmt.Sprintf("%s#%s", lexID, toPascal(name)))
+}
+
+func (m *IRIMapperAgent) FieldIRI(lexID, class, field string) string {
+	return fmt.Sprintf("%s/%s", m.ClassIRI(lexID, class), field)
+}

--- a/ontology/lexschema.go
+++ b/ontology/lexschema.go
@@ -1,0 +1,64 @@
+package ontology
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// LexDef represents a simplified lexicon definition.
+type LexDef struct {
+	LexiconID   string             `json:"-"`
+	Name        string             `json:"-"`
+	Type        string             `json:"type"`
+	Description string             `json:"description"`
+	Required    []string           `json:"required"`
+	Properties  map[string]LexProp `json:"properties"`
+}
+
+type LexProp struct {
+	Type        string   `json:"type"`
+	Ref         string   `json:"ref"`
+	Items       *LexProp `json:"items"`
+	Description string   `json:"description"`
+}
+
+type Lexicon struct {
+	ID   string            `json:"id"`
+	Defs map[string]LexDef `json:"defs"`
+}
+
+// LexSchemaAgent parses lexicon JSON into definitions.
+type LexSchemaAgent struct {
+	Defs map[string]LexDef
+}
+
+func NewLexSchemaAgent() *LexSchemaAgent {
+	return &LexSchemaAgent{Defs: map[string]LexDef{}}
+}
+
+func (l *LexSchemaAgent) Load(dir string) error {
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var lx Lexicon
+		if err := json.Unmarshal(b, &lx); err != nil {
+			return err
+		}
+		for name, def := range lx.Defs {
+			def.LexiconID = lx.ID
+			def.Name = name
+			l.Defs[lx.ID+"#"+name] = def
+		}
+		return nil
+	})
+}

--- a/ontology/pipeline.go
+++ b/ontology/pipeline.go
@@ -1,0 +1,103 @@
+package ontology
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// OntologyPipeline wires all agents together.
+type OntologyPipeline struct {
+	Prefix     *PrefixAgent
+	TypeInfer  *TypeInferAgent
+	IRIMapper  *IRIMapperAgent
+	LexSchema  *LexSchemaAgent
+	GoReflect  *GoReflectAgent
+	Godoc      *GodocAgent
+	RdfWriter  *RdfWriterAgent
+	Validator  *ValidationAgent
+	Provenance *ProvenanceAgent
+}
+
+func NewOntologyPipeline() *OntologyPipeline {
+	prefix := NewPrefixAgent()
+	return &OntologyPipeline{
+		Prefix:     prefix,
+		TypeInfer:  NewTypeInferAgent(),
+		IRIMapper:  NewIRIMapperAgent(prefix),
+		LexSchema:  NewLexSchemaAgent(),
+		GoReflect:  NewGoReflectAgent(),
+		Godoc:      NewGodocAgent(),
+		RdfWriter:  NewRdfWriterAgent(prefix),
+		Validator:  NewValidationAgent(),
+		Provenance: NewProvenanceAgent("atproto"),
+	}
+}
+
+// Run executes the ontology extraction pipeline.
+func (o *OntologyPipeline) Run(srcDir string, outPath string) error {
+	// Actual lexicon JSON files live under the atproto/lexicons directory.
+	lexDir := filepath.Join(srcDir, "atproto", "lexicons")
+	goDir := filepath.Join(srcDir, "indigo", "api", "bsky")
+
+	if err := o.LexSchema.Load(lexDir); err != nil {
+		return err
+	}
+	if err := o.GoReflect.Load(goDir); err != nil {
+		return err
+	}
+	if err := o.Godoc.Load(goDir); err != nil {
+		return err
+	}
+
+	for _, def := range o.LexSchema.Defs {
+		classIRI := fmt.Sprintf("<%s>", o.IRIMapper.ClassIRI(def.LexiconID, def.Name))
+		o.RdfWriter.WriteTriple(Triple{classIRI, "a", "owl:Class"})
+		desc := def.Description
+		sname := structName(def.LexiconID, def.Name)
+		if d, ok := o.Godoc.Docs[sname]; ok {
+			desc = strings.TrimSpace(d)
+		}
+		if desc != "" {
+			o.RdfWriter.WriteTriple(Triple{classIRI, "rdfs:comment", fmt.Sprintf("\"%s\"", desc)})
+		}
+		for propName, prop := range def.Properties {
+			fieldIRI := fmt.Sprintf("<%s>", o.IRIMapper.FieldIRI(def.LexiconID, def.Name, propName))
+			propType := "owl:DatatypeProperty"
+			rng := o.TypeInfer.InferDatatype(prop.Type)
+			if prop.Type == "ref" || (prop.Type == "array" && prop.Items != nil && prop.Items.Type == "ref") {
+				propType = "owl:ObjectProperty"
+				refName := strings.TrimPrefix(prop.Ref, "#")
+				if prop.Items != nil && prop.Items.Ref != "" {
+					refName = strings.TrimPrefix(prop.Items.Ref, "#")
+				}
+				rng = fmt.Sprintf("<%s>", o.IRIMapper.ClassIRI(def.LexiconID, refName))
+			}
+			o.RdfWriter.WriteTriple(Triple{fieldIRI, "a", propType})
+			o.RdfWriter.WriteTriple(Triple{fieldIRI, "rdfs:domain", classIRI})
+			o.RdfWriter.WriteTriple(Triple{fieldIRI, "rdfs:range", rng})
+			cmt := prop.Description
+			if d, ok := o.Godoc.Docs[sname+"."+toPascal(propName)]; ok {
+				cmt = strings.TrimSpace(d)
+			}
+			if cmt != "" {
+				o.RdfWriter.WriteTriple(Triple{fieldIRI, "rdfs:comment", fmt.Sprintf("\"%s\"", cmt)})
+			}
+		}
+	}
+	if err := o.Validator.Validate(o.RdfWriter.Buffer.String()); err != nil {
+		return err
+	}
+	return o.RdfWriter.Save(outPath)
+}
+
+func structName(lexID, defName string) string {
+	segs := strings.Split(lexID, ".")
+	base := ""
+	if len(segs) >= 2 {
+		base = toPascal(segs[len(segs)-2]) + toPascal(segs[len(segs)-1])
+	} else if len(segs) == 1 {
+		base = toPascal(segs[0])
+	}
+	return base + "_" + toPascal(defName)
+}

--- a/ontology/prefix.go
+++ b/ontology/prefix.go
@@ -1,0 +1,25 @@
+package ontology
+
+// PrefixAgent maintains ontology prefixes.
+type PrefixAgent struct {
+    Prefixes map[string]string
+}
+
+// NewPrefixAgent returns a PrefixAgent with default prefixes.
+func NewPrefixAgent() *PrefixAgent {
+    return &PrefixAgent{Prefixes: map[string]string{
+        "owl":  "http://www.w3.org/2002/07/owl#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "xsd":  "http://www.w3.org/2001/XMLSchema#",
+        "bsky": "https://atproto.social/ontology/",
+    }}
+}
+
+// IRI returns the expanded IRI for a given prefix and local name.
+func (p *PrefixAgent) IRI(prefix, local string) string {
+    base, ok := p.Prefixes[prefix]
+    if !ok {
+        return prefix + ":" + local
+    }
+    return base + local
+}

--- a/ontology/provenance.go
+++ b/ontology/provenance.go
@@ -1,0 +1,10 @@
+package ontology
+
+// ProvenanceAgent attaches minimal provenance information.
+type ProvenanceAgent struct {
+    Info string
+}
+
+func NewProvenanceAgent(info string) *ProvenanceAgent {
+    return &ProvenanceAgent{Info: info}
+}

--- a/ontology/rdfwriter.go
+++ b/ontology/rdfwriter.go
@@ -1,0 +1,37 @@
+package ontology
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+)
+
+// Triple represents a simple RDF triple.
+type Triple struct {
+	S string
+	P string
+	O string
+}
+
+// RdfWriterAgent writes triples to Turtle.
+type RdfWriterAgent struct {
+	Prefix *PrefixAgent
+	Buffer bytes.Buffer
+}
+
+func NewRdfWriterAgent(p *PrefixAgent) *RdfWriterAgent {
+	return &RdfWriterAgent{Prefix: p}
+}
+
+func (r *RdfWriterAgent) WriteTriple(t Triple) {
+	r.Buffer.WriteString(fmt.Sprintf("%s %s %s .\n", t.S, t.P, t.O))
+}
+
+func (r *RdfWriterAgent) Save(path string) error {
+	var out bytes.Buffer
+	for pref, iri := range r.Prefix.Prefixes {
+		out.WriteString(fmt.Sprintf("@prefix %s: <%s> .\n", pref, iri))
+	}
+	out.Write(r.Buffer.Bytes())
+	return os.WriteFile(path, out.Bytes(), 0644)
+}

--- a/ontology/typeinfer.go
+++ b/ontology/typeinfer.go
@@ -1,0 +1,28 @@
+package ontology
+
+import "strings"
+
+// TypeInferAgent infers XSD datatypes and OWL property types.
+type TypeInferAgent struct{}
+
+func NewTypeInferAgent() *TypeInferAgent { return &TypeInferAgent{} }
+
+// InferDatatype returns an XSD type based on input strings.
+func (t *TypeInferAgent) InferDatatype(goType string) string {
+	switch strings.TrimPrefix(goType, "[]") {
+	case "string":
+		return "xsd:string"
+	case "boolean", "bool":
+		return "xsd:boolean"
+	case "int", "int64", "uint", "uint64":
+		return "xsd:integer"
+	case "float32", "float64":
+		return "xsd:decimal"
+	case "bytes", "blob":
+		return "xsd:base64Binary"
+	case "record", "object", "array", "ref":
+		return "owl:Thing"
+	default:
+		return "owl:Thing"
+	}
+}

--- a/ontology/validation.go
+++ b/ontology/validation.go
@@ -1,0 +1,15 @@
+package ontology
+
+import "errors"
+
+// ValidationAgent performs minimal validation on TTL output.
+type ValidationAgent struct{}
+
+func NewValidationAgent() *ValidationAgent { return &ValidationAgent{} }
+
+func (v *ValidationAgent) Validate(content string) error {
+    if content == "" {
+        return errors.New("empty ontology")
+    }
+    return nil
+}


### PR DESCRIPTION
## Summary
- implement Codex agent pipeline for ontology reflection, using atproto lexicons and Go docs
- add prefix header and improved IRI mapping
- support doc comments and lexicon metadata when generating TTL
- regenerate full ontology in `build/lexicon.ttl`

## Testing
- `go build ./...`
- `go run . --emit-ontology`
- `go run . --doc-reflection | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_686197a6ab3c8327b52a1a6ab89e5bb7